### PR TITLE
Restore compatibility with current versions of the game

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build SubsystemLint
         run: dotnet build SubsystemLint/SubsystemLint.csproj -c Release --nologo
 
-      # The mod assembly references BBI.Core, BBI.Game.Data and UnityEngine from an installed
+      # The mod assembly references BBI.Core, BBI.Game.Data, BBI.Game and UnityEngine from an installed
       # copy of the game. Those cannot be redistributed, so build/Subsystem.Sdk.csproj is not
       # buildable on CI -- it is built locally against the game. See docs/building.md.
       - name: Check the mod project is still well-formed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tools:
+    name: Build tools
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build SubsystemPatcher
+        run: dotnet build SubsystemPatcher/SubsystemPatcher.csproj -c Release --nologo
+
+      - name: Build SubsystemLint
+        run: dotnet build SubsystemLint/SubsystemLint.csproj -c Release --nologo
+
+      # The mod assembly references BBI.Core, BBI.Game.Data and UnityEngine from an installed
+      # copy of the game. Those cannot be redistributed, so build/Subsystem.Sdk.csproj is not
+      # buildable on CI -- it is built locally against the game. See docs/building.md.
+      - name: Check the mod project is still well-formed
+        run: |
+          dotnet msbuild build/Subsystem.Sdk.csproj -t:CheckManagedDir -p:ManagedDir=/nonexistent \
+            -nologo 2>&1 | tee out.txt || true
+          grep -q "BBI.Core.dll not found in ManagedDir" out.txt \
+            || { echo "expected the ManagedDir guard to fire"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g. 0.5.0), for a dry run without tagging'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish tools
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Work out the version
+        id: version
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ inputs.version || '0.0.0-dev' }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Portable framework-dependent builds: one set of files that runs on Windows, Linux and
+      # macOS with the .NET 8+ runtime, which anyone building the mod already has.
+      - name: Publish SubsystemPatcher
+        run: >
+          dotnet publish SubsystemPatcher/SubsystemPatcher.csproj -c Release
+          -p:DebugType=none -p:Version=${{ steps.version.outputs.value }}
+          -o staging/SubsystemPatcher --nologo
+
+      - name: Publish SubsystemLint
+        run: >
+          dotnet publish SubsystemLint/SubsystemLint.csproj -c Release
+          -p:DebugType=none -p:Version=${{ steps.version.outputs.value }}
+          -o staging/SubsystemLint --nologo
+
+      - name: Assemble the package
+        run: |
+          cp README.md LICENSE.md patch.example.json staging/
+          cp -r docs staging/docs
+          # Keep the folder name: build/Subsystem.Sdk.csproj globs ../Subsystem/**/*.cs, so the
+          # archive has to preserve that layout for users to build the mod from it.
+          cp -r Subsystem staging/Subsystem
+          cp -r build staging/build
+          rm -rf staging/build/bin staging/build/obj staging/Subsystem/bin staging/Subsystem/obj
+          cd staging
+          zip -r "../Subsystem-tools-${{ steps.version.outputs.value }}.zip" . -x '*.pdb'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Subsystem-tools-${{ steps.version.outputs.value }}
+          path: Subsystem-tools-${{ steps.version.outputs.value }}.zip
+
+      - name: Create the GitHub release
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            "Subsystem-tools-${{ steps.version.outputs.value }}.zip" \
+            --title "Subsystem ${{ steps.version.outputs.value }}" \
+            --notes "$(cat <<'NOTES'
+          Install with `SubsystemPatcher`, which patches your own copy of `BBI.Unity.Game.dll`
+          rather than replacing it. See `README.md` in the archive.
+
+          Requires the .NET 8 SDK or newer. The mod assembly, `Subsystem.dll`, is built locally
+          against your installed game — its references cannot be redistributed:
+
+              dotnet build build/Subsystem.Sdk.csproj -c Release
+              cp build/bin/Release/net35/Subsystem.dll "<...>/Deserts of Kharak/Data/Managed/"
+              dotnet SubsystemPatcher/SubsystemPatcher.dll
+
+          Re-run the patcher after every game update.
+          NOTES
+          )"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,37 @@ before deciding what to set it to.
 
 See the [patch.json reference](docs/patch-reference.md) for every property you can set.
 
+### Changing stats for one player only
+
+`Entities` patches the shared unit templates, so it applies to everyone who fields that unit. To
+give one commander different numbers and leave the enemy's alone, use `Commanders`:
+
+```json
+{
+  "Commanders": {
+    "1": {
+      "EntityTypeBuffs": {
+        "C_Escort_MP": {
+          "Buffs": {
+            "0": { "Attribute": "Unit_MaxHealth", "Mode": "Set", "Value": 5000 },
+            "1": { "Attribute": "UnitDynamics_MaxSpeed", "Mode": "AddPercent", "Value": 25 }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This uses the game's own attribute-buff system — the one research upgrades run on — so the
+changes are saved with the game and survive loading a save. In exchange, only the attributes the
+engine can buff are reachable: health, armour, costs, speed, weapon damage and rate of fire,
+weapon ranges, ability cooldowns and a few dozen more. Anything else stays global.
+
+`Subsystem.log` prints the local and CPU commander IDs at match start, so you know which number
+to key on. See [Commanders](docs/patch-reference.md#commanders--changing-stats-for-one-player-only)
+for the full attribute list and the rules.
+
 ### Check your patch before you launch
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -8,81 +8,146 @@ Subsystem is currently in alpha. It may be extremely unstable, and it's not like
 
 ## Installation
 
-Place `Subsystem.dll` and `BBI.Unity.Game.dll` in the `Deserts of Kharak/Data/Managed/` folder. 
+> **The 0.4.0 release instructions no longer work.** See [Why the old install broke](#why-the-old-install-broke).
+> Use `SubsystemPatcher` instead — it patches the copy of `BBI.Unity.Game.dll` you already have,
+> so it keeps working on current versions of the game.
 
-`BBI.Unity.Game.dll` already exists and should be overwritten. You can make a backup of this file if you'd like.
+You need the [.NET SDK](https://dotnet.microsoft.com/download) (8.0 or newer).
+
+```sh
+# 1. build the mod assembly against your installed game
+dotnet build build/Subsystem.Sdk.csproj -c Release
+
+# 2. copy it into the game
+cp build/bin/Release/net35/Subsystem.dll "<...>/Deserts of Kharak/Data/Managed/"
+
+# 3. hook it into the game's own BBI.Unity.Game.dll
+dotnet run --project SubsystemPatcher -c Release
+```
+
+Both steps locate a Steam install automatically (including Flatpak Steam and Proton prefixes on
+Linux). If that fails, point them at the folder yourself:
+
+```sh
+dotnet build build/Subsystem.Sdk.csproj -c Release -p:ManagedDir="<...>/Deserts of Kharak/Data/Managed"
+dotnet run --project SubsystemPatcher -c Release -- --managed "<...>/Deserts of Kharak/Data/Managed"
+```
+
+Other `SubsystemPatcher` options:
+
+| Option | Effect |
+| --- | --- |
+| `--verify` | Report whether the hook and `Subsystem.dll` are installed, and whether `BBI.Unity.Game.dll` matches the rest of the install |
+| `--restore` | Put the original `BBI.Unity.Game.dll` back from the backup |
+| `--force` | Re-apply the hook even if it is already present |
+
+The original file is saved as `BBI.Unity.Game.dll.subsystem-backup` before anything is written.
+You can also always recover it with Steam: *Properties → Installed Files → Verify integrity*.
+
+**Re-run the patcher after every game update.** Steam replaces `BBI.Unity.Game.dll`, which removes
+the hook. The game will simply run unmodded until you patch it again.
+
+### Why the old install broke
+
+The 0.4.0 zip shipped a whole pre-patched `BBI.Unity.Game.dll` built against the November 2018
+game and told you to overwrite the game's own copy. The actual modification in that file is three
+IL instructions; everything else is just the 2018 game, so installing it rolls back years of game
+code. `SubsystemPatcher` applies those same three instructions to *your* copy instead.
+
+[docs/compatibility.md](docs/compatibility.md) has the full account: the hook, the 19 types and 51
+members the old assembly references that no longer exist, and the verification that the rewrite
+changes nothing else.
+
+## Documentation
+
+| | |
+| --- | --- |
+| [Finding names and values](docs/finding-names-and-values.md) | Discovering entity, component and weapon names for **your** install, and reading current values out of the logs |
+| [patch.json reference](docs/patch-reference.md) | Every patchable property, the enum values, and the rules that will bite you |
+| [Troubleshooting](docs/troubleshooting.md) | Symptom-first: nothing happened, a unit will not shoot, a change did not apply |
+| [Compatibility](docs/compatibility.md) | What broke in 2018, why, and how the fix works |
+| [Building and releasing](docs/building.md) | Build requirements, project layout, CI and releases |
 
 ## Usage
 
-Create a JSON file like this:
+Create a file at `Deserts of Kharak/Data/patch.json`. The name and location must match exactly,
+and all keys are case-sensitive.
 
 ```json
 {
   "Entities": {
-      "C_Escort_MP": {
-        "WeaponAttributes": {
-          "C_Escort_Weapon_G2G_MP": {
-            "BaseDamagePerRound": 14,
-            "ExcludeFromHeightAdvantage": true
-          }
-        },
-      },
-      "G_Baserunner_MP": {
-        "UnitAttributes": {
-          "MaxHealth": 3500,
-          "Armour": 3,
-          "Resource1Cost": 225,
-          "ProductionTime": 18.0
-        }
-      },
-      "Tier_3_C_Artillery": {
-        "ResearchItemAttributes": {
-          "Resource2Cost": 150,
-          "ResearchTime": 45.0,
-          "Dependencies": [
-            "Tier_2_C_ArmouredAssault"
-          ]
+    "C_Escort_MP": {
+      "WeaponAttributes": {
+        "C_Escort_Weapon_G2G_MP": {
+          "BaseDamagePerRound": 14,
+          "ExcludeFromHeightAdvantage": true
         }
       }
+    },
+    "G_Baserunner_MP": {
+      "UnitAttributes": {
+        "MaxHealth": 3500,
+        "Armour": 3,
+        "Resource1Cost": 225,
+        "ProductionTime": 18.0
+      }
+    }
   }
 }
 ```
 
-Save the file and place it at `Deserts of Kharak/Data/patch.json`. The filename and location must match exactly.
+Stats are reloaded at the beginning of every match. `patch.example.json` is the same file, ready
+to copy.
 
-Note that the keys (`Entities`, `UnitAttributes`, etc) are case-sensitive.
+After a match starts, `Data/Subsystem.log` lists everything that changed along with each field's
+**previous** value — which is also the easiest way to learn the game's native scale for a stat
+before deciding what to set it to.
 
-The stats are reloaded at the beginning of every game, 
+See the [patch.json reference](docs/patch-reference.md) for every property you can set.
 
-### Multiplayer Notes
+### Check your patch before you launch
 
-To use this in multiplayer, all players in the game **must** have the same version of Subsystem *and* the same `patch.json` file contents. If any player has different data, the game is liable to crash with a synchronization error.
-
-### Modifiable Attributes
-
-See these source files for a list of attributes that can be modified:
-
-* [AbilityAttributesPatch.cs](https://github.com/Majiir/Subsystem/blob/develop/Subsystem/AbilityAttributesPatch.cs)
-* [ResearchItemAttributesPatch.cs](https://github.com/Majiir/Subsystem/blob/develop/Subsystem/ResearchItemAttributesPatch.cs)
-* [UnitAttributesPatch.cs](https://github.com/Majiir/Subsystem/blob/develop/Subsystem/UnitAttributesPatch.cs)
-* [WeaponAttributesPatch.cs](https://github.com/Majiir/Subsystem/blob/develop/Subsystem/WeaponAttributesPatch.cs)
-
-### Entity Names
-
-This gist shows a dump of all named entity components: https://gist.github.com/Majiir/1c78930ad70a16e1bd9a116948f55409
-
-### Serialization Notes
-
-* Some enums are marked with `[Flags]`. You must use a particular syntax in order to assign multiple flags. For example, to set a unit's `Class` to multiple values:
-
-```json
-...
-"UnitAttributes": {
-  "Class": "Hover, Carrier"
-}
-...
+```sh
+dotnet run --project SubsystemLint -c Release
 ```
 
-* Non-flags enums should be set as strings. (Example: `"HackableProperties": "InstantHackable"`)
+It reports unknown keys, wrong value types, invalid enum values, list keys that are not integers,
+and entity and component names that do not exist in your install — with spelling suggestions.
+Exit code 0 when clean, 2 when it finds problems.
 
-* `Fixed64` values are set as Numbers (equivalent to `double`) in JSON. This is technically a lossy conversion, but it will work well in most circumstances.
+Worth running every time, because **a single unknown key discards your entire patch**. LitJson's
+`ignore_extra_keys` defaults to `false`, so one unrecognised property makes the whole document
+throw; `AttributeLoader` catches it, logs one line to `output_log.txt`, and applies nothing at
+all. "My change did nothing" is usually a typo somewhere else in the file.
+
+### Finding entity and component names
+
+Every game start, Subsystem writes `Data/Subsystem.entities.log` — every entity type the game
+loaded, its components, and each weapon's ranges, auto-fire flags and target-class modifiers:
+
+```
+C_HAC_Upgrade01_MP
+    UnitAttributesData: C_HAC_Upgrade01_UnitAttributesAsset_MP
+    WeaponAttributesData: C_HAC_Upgrade01_Weapon_G2A_MP
+        auto-acquire: yes   auto-fire: yes   damage: 250   cooldown: 700ms
+        ranges: Short=1400 Medium=1400 Long=1400
+        vs Air (Or): CanTarget 1
+```
+
+Generated from what your install actually loaded, so it stays correct across game updates and
+DLC. [Finding names and values](docs/finding-names-and-values.md) explains how to read it, how to
+work out which entity is which unit, and why campaign and multiplayer are separate entities.
+
+The [2018 gist](https://gist.github.com/Majiir/1c78930ad70a16e1bd9a116948f55409) of entity names
+is still around, but some of those names no longer exist. Prefer the dump.
+
+### Multiplayer
+
+All players must have the same version of Subsystem **and** byte-identical `patch.json`, or the
+game will desync.
+
+### Serialization notes
+
+* `[Flags]` enums take one comma-separated string: `"Class": "Hover, Carrier"`
+* Other enums are plain strings: `"HackableProperties": "InstantHackable"`
+* `Fixed64` values are written as JSON numbers. Technically lossy, fine in practice.

--- a/Subsystem/AttributeLoader.cs
+++ b/Subsystem/AttributeLoader.cs
@@ -27,6 +27,22 @@ namespace Subsystem
 
         public void LoadAttributes(EntityTypeCollection entityTypeCollection)
         {
+            // Written before the patch is read, and in its own try/catch, so the name reference
+            // is still produced when patch.json is missing or malformed -- that is exactly when
+            // it is most useful.
+            try
+            {
+                var dumpPath = Path.Combine(Application.dataPath, "Subsystem.entities.log");
+                using (var dumpWriter = new StreamWriter(dumpPath))
+                {
+                    EntityTypeDumper.Dump(entityTypeCollection, dumpWriter);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[SUBSYSTEM] Error writing entity type dump: {e}");
+            }
+
             try
             {
                 var jsonPath = Path.Combine(Application.dataPath, "patch.json");

--- a/Subsystem/AttributeLoader.cs
+++ b/Subsystem/AttributeLoader.cs
@@ -25,6 +25,14 @@ namespace Subsystem
             logger = new StringLogger(writer);
         }
 
+        // Lets CommanderBuffLoader reuse the buff-list patching below and have it write into the
+        // same log. Only the Apply* methods are usable on an instance built this way; LoadAttributes
+        // and ApplyAttributesPatch own the log file and need the writer.
+        public AttributeLoader(StringLogger logger)
+        {
+            this.logger = logger;
+        }
+
         public void LoadAttributes(EntityTypeCollection entityTypeCollection)
         {
             // Written before the patch is read, and in its own try/catch, so the name reference
@@ -307,10 +315,10 @@ namespace Subsystem
             var attributeBuffSetWrapper = new AttributeBuffSetWrapper(experienceLevelAttributesWrapper.Buff);
             experienceLevelAttributesWrapper.Buff = attributeBuffSetWrapper;
 
-            applyAttributeBuffSetPatch(experienceLevelAttributesPatch.Buff, attributeBuffSetWrapper);
+            ApplyAttributeBuffSetPatch(experienceLevelAttributesPatch.Buff, attributeBuffSetWrapper);
         }
 
-        private void applyAttributeBuffSetPatch(Dictionary<string, AttributeBuffPatch> patch, AttributeBuffSetWrapper wrapper)
+        public void ApplyAttributeBuffSetPatch(Dictionary<string, AttributeBuffPatch> patch, AttributeBuffSetWrapper wrapper)
         {
             applyListPatch(patch, wrapper.Buffs, () => new AttributeBuffWrapper(), applyAttributeBuffPatch, nameof(AttributeBuff));
         }

--- a/Subsystem/AttributeLoader.cs
+++ b/Subsystem/AttributeLoader.cs
@@ -225,14 +225,28 @@ namespace Subsystem
         private void applyListPatch<TPatch, TWrapper>(Dictionary<string, TPatch> patch, List<TWrapper> wrappers, Func<TWrapper> createWrapper, Action<TPatch, TWrapper> applyPatch, string elementName)
             where TWrapper : class
         {
-            foreach (var kvp in patch.OrderBy(x => x.Key))
+            // Sort by the numeric index, not by the key string. Ordinal order puts "10" between
+            // "1" and "2", so any list with more than ten entries used to hit the
+            // non-consecutive-index check at "10" and silently drop everything from there on.
+            var ordered = new List<KeyValuePair<int, TPatch>>();
+
+            foreach (var kvp in patch)
             {
-                if (!int.TryParse(kvp.Key, out var index))
+                if (!int.TryParse(kvp.Key, out var parsed))
                 {
                     logger.Log($"ERROR: Non-integer key: {kvp.Key}");
+                    ordered.Clear();
                     break;
                 }
 
+                ordered.Add(new KeyValuePair<int, TPatch>(parsed, kvp.Value));
+            }
+
+            ordered.Sort((a, b) => a.Key.CompareTo(b.Key));
+
+            foreach (var kvp in ordered)
+            {
+                var index = kvp.Key;
                 var elementPatch = kvp.Value;
 
                 using (logger.BeginScope($"{elementName}: {index}"))

--- a/Subsystem/CommanderBuffLoader.cs
+++ b/Subsystem/CommanderBuffLoader.cs
@@ -1,0 +1,345 @@
+using BBI.Core.Data;
+using BBI.Game.Data;
+using BBI.Game.SaveLoad;
+using BBI.Game.Simulation;
+using LitJson;
+using Subsystem.Patch;
+using Subsystem.Wrappers;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+
+namespace Subsystem
+{
+    /// <summary>
+    /// Applies the "Commanders" section of patch.json: stat changes that affect one commander's
+    /// units only, instead of every unit of that type on the map.
+    ///
+    /// The "Entities" section patches the shared entity type templates, so it necessarily hits
+    /// every player. The engine keeps a *per-commander* copy of each buffable entity type
+    /// (EntityTypeCollection.GetCommanderSpecificEntityType) and modifies it with attribute
+    /// buffs — that is how a research upgrade gives one player better tanks and leaves the
+    /// enemy's alone. This applies the same mechanism from patch.json.
+    ///
+    /// Two consequences of using the game's own buff system rather than patching the
+    /// per-commander copy directly:
+    ///
+    ///  - buffs are saved with the game (SkirmishSaveState.CommanderTypeBuffs) and restored by
+    ///    Sim.OnLoad, so they survive loading a save. Component patches would not: OnLoad calls
+    ///    ResetUserSpecificEntityTypes and rebuilds the per-commander copies from scratch.
+    ///  - only the attributes the engine can buff are reachable. That is Buff.CategoryAndID,
+    ///    not the whole of patch.json.
+    ///
+    /// This runs from a second hook, after the Sim has been constructed: the per-commander
+    /// copies do not exist until Sim's constructor calls MakeAllTypesBuffableForCommander, so
+    /// none of this can be done from AttributeLoader's hook.
+    /// </summary>
+    public class CommanderBuffLoader
+    {
+        private const string ExtensionsTypeName = "BBI.Game.Simulation.EntityTypeBuffExtensions";
+
+        // EntityTypeBuffExtensions is internal to BBI.Game. Re-implementing it here would mean
+        // duplicating eleven component categories and keeping them in step with the game across
+        // updates; calling the game's own code is shorter and correct by construction.
+        private static MethodInfo sAddBuffsForCommander;
+        private static MethodInfo sGetAllEntityTypeBuffs;
+
+        private readonly StringWriter writer;
+        private readonly StringLogger logger;
+        private readonly AttributeLoader buffSetPatcher;
+
+        // Snapshot of every entity type name, taken once: nothing adds types after the sim is up,
+        // and there are ~900 of them to walk per entry otherwise.
+        private List<string> entityTypeNames;
+
+        public CommanderBuffLoader()
+        {
+            writer = new StringWriter();
+            logger = new StringLogger(writer);
+            buffSetPatcher = new AttributeLoader(logger);
+        }
+
+        public void ApplyCommanderBuffs(EntityTypeCollection entityTypeCollection)
+        {
+            try
+            {
+                var patch = readPatch();
+                if (patch == null || patch.Commanders.Count == 0) { return; }
+
+                if (!resolveEngineApi()) { flush(); return; }
+
+                entityTypeNames = new List<string>();
+                foreach (var name in entityTypeCollection.GetAllEntityTypeNames())
+                {
+                    entityTypeNames.Add(name);
+                }
+                entityTypeNames.Sort(StringComparer.Ordinal);
+
+                using (logger.BeginScope("Commander buffs"))
+                {
+                    logCommanderRoster();
+
+                    foreach (var kvp in patch.Commanders)
+                    {
+                        applyCommanderPatch(entityTypeCollection, kvp.Key, kvp.Value);
+                    }
+                }
+
+                flush();
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[SUBSYSTEM] Error applying commander buffs: {e}");
+            }
+        }
+
+        // patch.json is read again rather than handed over from AttributeLoader: the two hooks
+        // are far apart in the game's start-up, and a null static between them would silently
+        // apply nothing after any future reordering. Re-reading one small file at match start
+        // costs nothing. A malformed file has already been reported by AttributeLoader.
+        private static AttributesPatch readPatch()
+        {
+            var jsonPath = Path.Combine(Application.dataPath, "patch.json");
+            if (!File.Exists(jsonPath)) { return null; }
+
+            return JsonMapper.ToObject<AttributesPatch>(File.ReadAllText(jsonPath));
+        }
+
+        private bool resolveEngineApi()
+        {
+            if (sAddBuffsForCommander != null && sGetAllEntityTypeBuffs != null) { return true; }
+
+            var type = typeof(CommanderID).Assembly.GetType(ExtensionsTypeName);
+            if (type == null)
+            {
+                logger.Log($"ERROR: {ExtensionsTypeName} not found in BBI.Game — the game's code changed shape, commander buffs are unavailable");
+                return false;
+            }
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.Static;
+
+            sAddBuffsForCommander = type.GetMethod("AddBuffsForCommander", flags, null,
+                new[] { typeof(EntityTypeCollection), typeof(string), typeof(AttributeBuffSet), typeof(CommanderID), typeof(bool) }, null);
+
+            sGetAllEntityTypeBuffs = type.GetMethod("GetAllEntityTypeBuffs", flags, null,
+                new[] { typeof(EntityTypeAttributes) }, null);
+
+            if (sAddBuffsForCommander == null || sGetAllEntityTypeBuffs == null)
+            {
+                logger.Log($"ERROR: {ExtensionsTypeName} no longer has the expected AddBuffsForCommander/GetAllEntityTypeBuffs — commander buffs are unavailable");
+                sAddBuffsForCommander = null;
+                sGetAllEntityTypeBuffs = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// The commander IDs in play, so that "which number am I?" is answered by the log instead
+        /// of by guesswork. SimController caches the first two in PostLoadInit, which is the call
+        /// this hook is injected after, so they are populated by now.
+        /// </summary>
+        private void logCommanderRoster()
+        {
+            logger.Log($"local commander: {SimController.LocalPlayerCommanderID.ID}");
+            logger.Log($"first enemy CPU commander: {SimController.EnemyCPUCommander.ID}");
+
+            // Sim.Instance and Sim.CommanderManager are not public. The full roster is a
+            // diagnostic and nothing depends on it, so a failure here costs a log line and
+            // no more.
+            try
+            {
+                var simType = typeof(SimController).Assembly.GetType("BBI.Game.Simulation.Sim");
+                var instanceField = simType.GetField("Instance", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                var managerProperty = simType.GetProperty("CommanderManager", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+                var manager = managerProperty.GetValue(instanceField.GetValue(null), null);
+                var commandersField = manager.GetType().GetField("mCommanders", BindingFlags.NonPublic | BindingFlags.Instance);
+                var commanders = (IDictionary)commandersField.GetValue(manager);
+
+                foreach (DictionaryEntry entry in commanders)
+                {
+                    var commander = (Commander)entry.Value;
+                    logger.Log($"  commander {commander.ID.ID}: {commander.Name} (team {commander.TeamID.ID})");
+                }
+            }
+            catch (Exception e)
+            {
+                logger.Log($"  (full commander roster unavailable: {e.Message})");
+            }
+        }
+
+        private void applyCommanderPatch(EntityTypeCollection entityTypeCollection, string key, CommanderPatch commanderPatch)
+        {
+            using (logger.BeginScope($"Commander: {key}"))
+            {
+                int id;
+                if (!int.TryParse(key, out id))
+                {
+                    logger.Log($"ERROR: '{key}' is not a commander ID (a whole number)");
+                    return;
+                }
+
+                var commanderID = new CommanderID(id);
+
+                foreach (var kvp in commanderPatch.EntityTypeBuffs)
+                {
+                    applyEntityTypeBuffPatch(entityTypeCollection, commanderID, kvp.Key, kvp.Value);
+                }
+            }
+        }
+
+        private void applyEntityTypeBuffPatch(EntityTypeCollection entityTypeCollection, CommanderID commanderID, string typeSpec, EntityTypeBuffPatch patch)
+        {
+            using (logger.BeginScope($"EntityType: {typeSpec}"))
+            {
+                var desired = new AttributeBuffSetWrapper();
+                buffSetPatcher.ApplyAttributeBuffSetPatch(patch.Buffs, desired);
+
+                // Commander_* buffs go on the Commander object, not on an entity type.
+                // Sim.AddEntityTypeBuffs does that through API that is internal to BBI.Game and
+                // out of reach here, so reject them rather than accept them and do nothing.
+                for (var i = desired.Buffs.Count - 1; i >= 0; i--)
+                {
+                    if (desired.Buffs[i].Category != Buff.Category.Commander) { continue; }
+
+                    logger.Log($"ERROR: Buffs.{i} is a Commander_* buff, which is not supported here — ignored");
+                    desired.Buffs.RemoveAt(i);
+                }
+
+                if (desired.Buffs.Count == 0)
+                {
+                    logger.Log("NOTICE: no buffs to apply");
+                    return;
+                }
+
+                var matched = 0;
+
+                foreach (var entityTypeName in matchingEntityTypes(entityTypeCollection, typeSpec, patch))
+                {
+                    matched++;
+                    applyToEntityType(entityTypeCollection, commanderID, entityTypeName, desired);
+                }
+
+                if (matched == 0)
+                {
+                    logger.Log("NOTICE: matched no entity type with UnitAttributes");
+                }
+            }
+        }
+
+        // Mirrors the matching Sim.AddEntityTypeBuffs does: name or name prefix, an optional
+        // UnitClass filter, and only types that have UnitAttributes — the engine will not buff
+        // anything else.
+        private List<string> matchingEntityTypes(EntityTypeCollection entityTypeCollection, string typeSpec, EntityTypeBuffPatch patch)
+        {
+            var useAsPrefix = patch.UseAsPrefix ?? false;
+            var unitClass = patch.UnitClass ?? UnitClass.None;
+            var classOperator = patch.ClassOperator ?? FlagOperator.Or;
+
+            var matches = new List<string>();
+
+            foreach (var name in entityTypeNames)
+            {
+                if (useAsPrefix ? !name.StartsWith(typeSpec) : name != typeSpec) { continue; }
+
+                var entityType = entityTypeCollection.GetEntityType(name);
+                if (entityType == null) { continue; }
+
+                var unitAttributes = entityType.Get<UnitAttributes>();
+                if (unitAttributes == null) { continue; }
+
+                if (unitClass != UnitClass.None && !classMatches(unitAttributes.Class, unitClass, classOperator)) { continue; }
+
+                matches.Add(name);
+            }
+
+            return matches;
+        }
+
+        private static bool classMatches(UnitClass actual, UnitClass wanted, FlagOperator classOperator)
+        {
+            return classOperator == FlagOperator.And
+                ? (actual & wanted) == wanted
+                : (actual & wanted) != 0;
+        }
+
+        private void applyToEntityType(EntityTypeCollection entityTypeCollection, CommanderID commanderID, string entityTypeName, AttributeBuffSetWrapper desired)
+        {
+            var entityType = entityTypeCollection.GetCommanderSpecificEntityType(entityTypeName, commanderID.ID);
+            if (entityType == null)
+            {
+                logger.Log($"{entityTypeName}: ERROR: no commander-specific entity type");
+                return;
+            }
+
+            var existing = (IDBuffSaveState[])sGetAllEntityTypeBuffs.Invoke(null, new object[] { entityType });
+
+            // Loading a save re-runs this hook, and Sim.OnLoad has already restored the buffs
+            // that were saved. Adding them a second time would double an Add or AddPercent, so
+            // only buffs that are not already on this type are applied. Two identical entries in
+            // one Buffs list therefore collapse into one.
+            var fresh = new AttributeBuffSetWrapper();
+            foreach (var buff in desired.Buffs)
+            {
+                if (!alreadyApplied(existing, buff)) { fresh.Buffs.Add(buff); }
+            }
+
+            if (fresh.Buffs.Count == 0)
+            {
+                logger.Log($"{entityTypeName}: already applied");
+                return;
+            }
+
+            // Not silent. The BuffChangedEvent is what makes units that already exist pick the
+            // change up: Unit.OnBuffChangedEvent rescales Health against the new MaxHealth and
+            // calls CheckRebindWeapons. Campaign missions restore the carried-over fleet during
+            // SimController.Initialize, which is before this hook runs, so suppressing the event
+            // left every surviving unit on its old health and its old weapons.
+            sAddBuffsForCommander.Invoke(null, new object[] { entityTypeCollection, entityTypeName, fresh, commanderID, false });
+
+            logger.Log($"{entityTypeName}: applied {fresh.Buffs.Count} of {desired.Buffs.Count} buff(s)");
+        }
+
+        private static bool alreadyApplied(IDBuffSaveState[] existing, AttributeBuffWrapper buff)
+        {
+            if (existing == null) { return false; }
+
+            foreach (var state in existing)
+            {
+                if (state.Category != buff.Category) { continue; }
+
+                // An empty Name in the patch means "every component in this category", which is
+                // how AttributeBuffSet.GetBuffs reads it.
+                if (!string.IsNullOrEmpty(buff.Name) && state.ID != buff.Name) { continue; }
+
+                if (state.Buffs == null) { continue; }
+
+                foreach (var applied in state.Buffs)
+                {
+                    if (applied.AttributeID == buff.AttributeID
+                        && applied.Mode == buff.Mode
+                        && applied.Value == buff.Value)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        // AttributeLoader has already written Subsystem.log by the time this runs.
+        private void flush()
+        {
+            var log = writer.ToString();
+            if (log.Length == 0) { return; }
+
+            File.AppendAllText(Path.Combine(Application.dataPath, "Subsystem.log"), Environment.NewLine + log);
+        }
+    }
+}

--- a/Subsystem/CommanderBuffLoader.cs
+++ b/Subsystem/CommanderBuffLoader.cs
@@ -40,6 +40,9 @@ namespace Subsystem
     public class CommanderBuffLoader
     {
         private const string ExtensionsTypeName = "BBI.Game.Simulation.EntityTypeBuffExtensions";
+        private const string BuffedAbilityTypeName = "BBI.Game.Simulation.BuffedAbilityAttributes";
+
+        private static ConstructorInfo sBuffedAbilityCtor;
 
         // EntityTypeBuffExtensions is internal to BBI.Game. Re-implementing it here would mean
         // duplicating eleven component categories and keeping them in step with the game across
@@ -186,6 +189,13 @@ namespace Subsystem
 
                 var commanderID = new CommanderID(id);
 
+                // Grants first: an Ability_* buff in the same patch then reaches an ability that
+                // was only just added.
+                foreach (var kvp in commanderPatch.AddAbilities)
+                {
+                    applyAbilityGrantPatch(entityTypeCollection, commanderID, kvp.Key, kvp.Value);
+                }
+
                 foreach (var kvp in commanderPatch.EntityTypeBuffs)
                 {
                     applyEntityTypeBuffPatch(entityTypeCollection, commanderID, kvp.Key, kvp.Value);
@@ -219,7 +229,8 @@ namespace Subsystem
 
                 var matched = 0;
 
-                foreach (var entityTypeName in matchingEntityTypes(entityTypeCollection, typeSpec, patch))
+                foreach (var entityTypeName in matchingEntityTypes(entityTypeCollection, typeSpec,
+                             patch.UseAsPrefix, patch.UnitClass, patch.ClassOperator))
                 {
                     matched++;
                     applyToEntityType(entityTypeCollection, commanderID, entityTypeName, desired);
@@ -235,11 +246,12 @@ namespace Subsystem
         // Mirrors the matching Sim.AddEntityTypeBuffs does: name or name prefix, an optional
         // UnitClass filter, and only types that have UnitAttributes — the engine will not buff
         // anything else.
-        private List<string> matchingEntityTypes(EntityTypeCollection entityTypeCollection, string typeSpec, EntityTypeBuffPatch patch)
+        private List<string> matchingEntityTypes(EntityTypeCollection entityTypeCollection, string typeSpec,
+            bool? useAsPrefixOrNull, UnitClass? unitClassOrNull, FlagOperator? classOperatorOrNull)
         {
-            var useAsPrefix = patch.UseAsPrefix ?? false;
-            var unitClass = patch.UnitClass ?? UnitClass.None;
-            var classOperator = patch.ClassOperator ?? FlagOperator.Or;
+            var useAsPrefix = useAsPrefixOrNull ?? false;
+            var unitClass = unitClassOrNull ?? UnitClass.None;
+            var classOperator = classOperatorOrNull ?? FlagOperator.Or;
 
             var matches = new List<string>();
 
@@ -259,6 +271,179 @@ namespace Subsystem
             }
 
             return matches;
+        }
+
+        private void applyAbilityGrantPatch(EntityTypeCollection entityTypeCollection, CommanderID commanderID, string typeSpec, EntityTypeAbilityPatch patch)
+        {
+            using (logger.BeginScope($"AddAbilities: {typeSpec}"))
+            {
+                var grants = new List<KeyValuePair<int, AbilityGrantPatch>>();
+
+                foreach (var kvp in patch.Abilities)
+                {
+                    if (!int.TryParse(kvp.Key, out var parsed))
+                    {
+                        logger.Log($"ERROR: Non-integer key: {kvp.Key}");
+                        return;
+                    }
+
+                    grants.Add(new KeyValuePair<int, AbilityGrantPatch>(parsed, kvp.Value));
+                }
+
+                grants.Sort((a, b) => a.Key.CompareTo(b.Key));
+
+                var matched = 0;
+
+                foreach (var entityTypeName in matchingEntityTypes(entityTypeCollection, typeSpec,
+                             patch.UseAsPrefix, patch.UnitClass, patch.ClassOperator))
+                {
+                    matched++;
+
+                    foreach (var grant in grants)
+                    {
+                        grantAbility(entityTypeCollection, commanderID, entityTypeName, grant.Value);
+                    }
+                }
+
+                if (matched == 0)
+                {
+                    logger.Log("NOTICE: matched no entity type with UnitAttributes");
+                }
+            }
+        }
+
+        private void grantAbility(EntityTypeCollection entityTypeCollection, CommanderID commanderID, string entityTypeName, AbilityGrantPatch grant)
+        {
+            if (string.IsNullOrEmpty(grant.From))
+            {
+                logger.Log($"{entityTypeName}: ERROR: no From given");
+                return;
+            }
+
+            var donor = findAbility(entityTypeCollection.GetEntityType(grant.From));
+            if (donor == null)
+            {
+                logger.Log($"{entityTypeName}: ERROR: '{grant.From}' is not an entity type carrying an ability");
+                return;
+            }
+
+            var entityType = entityTypeCollection.GetCommanderSpecificEntityType(entityTypeName, commanderID.ID);
+            if (entityType == null)
+            {
+                logger.Log($"{entityTypeName}: ERROR: no commander-specific entity type");
+                return;
+            }
+
+            if (entityType.Get<AbilityAttributes>(donor.Name) != null)
+            {
+                logger.Log($"{entityTypeName}: already has {donor.Name}");
+                return;
+            }
+
+            if ((grant.SkipIfSelfHealing ?? true) && selfHeals(entityType))
+            {
+                logger.Log($"{entityTypeName}: skipped, already regenerates");
+                return;
+            }
+
+            // MakeAllTypesBuffableForCommander wraps every ability on every commander copy and
+            // sets the Ability category-buffed flag, after which AddAbilityBuffs casts each
+            // ability to BuffedAbilityAttributes without checking. Adding a bare one would make
+            // the next ability buff on this unit throw -- including one the game itself applies
+            // through a research upgrade. So add it wrapped, the way the engine would have.
+            var wrapped = wrapAbility(donor);
+            if (wrapped == null)
+            {
+                logger.Log($"{entityTypeName}: ERROR: could not wrap {donor.Name}; not added");
+                return;
+            }
+
+            entityType.Add(wrapped);
+
+            logger.Log($"{entityTypeName}: added {donor.Name} ({describeHealing(donor)})");
+        }
+
+        private static AbilityAttributes findAbility(EntityTypeAttributes entityType)
+        {
+            if (entityType == null) { return null; }
+
+            var abilities = entityType.GetAll<AbilityAttributes>();
+            return abilities != null && abilities.Length > 0 ? abilities[0] : null;
+        }
+
+        /// <summary>
+        /// Whether any ability on this type already applies a healing health-over-time effect --
+        /// "does it regenerate by itself", without hard-coding a list of ability names.
+        /// </summary>
+        private static bool selfHeals(EntityTypeAttributes entityType)
+        {
+            var abilities = entityType.GetAll<AbilityAttributes>();
+            if (abilities == null) { return false; }
+
+            foreach (var ability in abilities)
+            {
+                if (healPerSecond(ability) > 0) { return true; }
+            }
+
+            return false;
+        }
+
+        private static int healPerSecond(AbilityAttributes ability)
+        {
+            if (ability == null) { return 0; }
+
+            var apply = ability.ApplyStatusEffect;
+            if (apply == null || apply.StatusEffectsToApply == null) { return 0; }
+
+            var total = 0;
+
+            foreach (var effect in apply.StatusEffectsToApply)
+            {
+                if (effect == null || effect.Modifiers == null) { continue; }
+
+                foreach (var modifier in effect.Modifiers)
+                {
+                    var healthOverTime = modifier.HealthOverTimeAttributes;
+                    if (healthOverTime.Amount <= 0 || healthOverTime.DamageType != DamageType.Heal) { continue; }
+                    if (healthOverTime.MSTickDuration <= 0) { continue; }
+
+                    total += healthOverTime.Amount * 1000 / healthOverTime.MSTickDuration;
+                }
+            }
+
+            return total;
+        }
+
+        private string describeHealing(AbilityAttributes ability)
+        {
+            var perSecond = healPerSecond(ability);
+
+            if (perSecond <= 0)
+            {
+                return $"targeting {ability.TargetingType}, no healing effect";
+            }
+
+            return ability.TargetingType == AbilityTargetingType.Passive
+                ? $"{perSecond} health/sec, passive"
+                : $"{perSecond} health/sec, targeting {ability.TargetingType} — NOT passive, so it will not fire on its own";
+        }
+
+        private object wrapAbility(AbilityAttributes ability)
+        {
+            if (sBuffedAbilityCtor == null)
+            {
+                var type = typeof(CommanderID).Assembly.GetType(BuffedAbilityTypeName);
+                if (type == null) { return null; }
+
+                sBuffedAbilityCtor = type.GetConstructor(
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null,
+                    new[] { typeof(AbilityAttributes), typeof(int), typeof(int) }, null);
+
+                if (sBuffedAbilityCtor == null) { return null; }
+            }
+
+            // 4, 4: Buff.ID.Ability has four attributes, which is the hint the engine passes.
+            return sBuffedAbilityCtor.Invoke(new object[] { ability, 4, 4 });
         }
 
         private static bool classMatches(UnitClass actual, UnitClass wanted, FlagOperator classOperator)

--- a/Subsystem/EntityTypeDumper.cs
+++ b/Subsystem/EntityTypeDumper.cs
@@ -1,0 +1,119 @@
+using BBI.Core;
+using BBI.Core.Data;
+using BBI.Game.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Subsystem
+{
+    // Writes out every entity type the game actually loaded, with the components attached to
+    // each one. Component names are what patch.json keys on, so this is the authoritative
+    // answer to "what can I write in patch.json" for the version of the game you have
+    // installed -- unlike a name list scraped from asset files, which misses anything the
+    // build compresses or renames.
+    public static class EntityTypeDumper
+    {
+        // For weapons, the interesting question is "what can this thing actually shoot, and does
+        // it do so on its own" -- which is the auto-fire flags plus the per-target-class
+        // modifiers, not the damage numbers.
+        private static string DescribeWeapon(WeaponAttributes weapon)
+        {
+            if (weapon == null) { return ""; }
+
+            var sb = new StringBuilder();
+
+            sb.AppendFormat("        auto-acquire: {0}   auto-fire: {1}   damage: {2}   cooldown: {3}ms\n",
+                weapon.ExcludeFromAutoTargetAcquisition ? "no" : "yes",
+                weapon.ExcludeFromAutoFire ? "no" : "yes",
+                weapon.BaseDamagePerRound,
+                weapon.CooldownTimeMS);
+
+            sb.AppendFormat("        DamageType: {0}   TargetStyle: {1}\n",
+                weapon.DamageType, weapon.TargetStyle);
+
+            if (weapon.Ranges != null && weapon.Ranges.Length > 0)
+            {
+                sb.Append("        ranges:");
+                foreach (var range in weapon.Ranges)
+                {
+                    if (range == null) { continue; }
+                    sb.AppendFormat(" {0}={1}", range.Range, range.Distance);
+                }
+                sb.Append("\n");
+            }
+
+            if (weapon.Modifiers != null && weapon.Modifiers.Length > 0)
+            {
+                foreach (var modifier in weapon.Modifiers)
+                {
+                    if (modifier == null) { continue; }
+                    sb.AppendFormat("        vs {0} ({1}): {2} {3}\n",
+                        modifier.TargetClass, modifier.ClassOperator, modifier.Modifier, modifier.Amount);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        public static void Dump(EntityTypeCollection entityTypeCollection, TextWriter writer)
+        {
+            var names = new List<string>();
+            foreach (var name in entityTypeCollection.GetAllEntityTypeNames())
+            {
+                names.Add(name);
+            }
+            names.Sort(StringComparer.Ordinal);
+
+            writer.WriteLine("# Subsystem entity type dump");
+            writer.WriteLine("# {0} entity types", names.Count);
+            writer.WriteLine("#");
+            writer.WriteLine("# Each entry is an \"Entities\" key in patch.json. Indented lines are the");
+            writer.WriteLine("# components on that entity; a component shown as \"Type: Name\" is keyed by");
+            writer.WriteLine("# that name in patch.json, one shown as just \"Type\" is not.");
+            writer.WriteLine();
+
+            foreach (var name in names)
+            {
+                writer.WriteLine(name);
+
+                var entityType = entityTypeCollection.GetEntityType(name);
+                if (entityType == null)
+                {
+                    writer.WriteLine("    (could not be resolved)");
+                    continue;
+                }
+
+                var components = entityType.GetAll<object>();
+                if (components == null || components.Length == 0)
+                {
+                    writer.WriteLine("    (no components)");
+                    continue;
+                }
+
+                var entries = new List<KeyValuePair<string, string>>();
+                foreach (var component in components)
+                {
+                    if (component == null) { continue; }
+
+                    var typeName = component.GetType().Name;
+                    var named = component as INamed;
+
+                    var header = named != null && !string.IsNullOrEmpty(named.Name)
+                        ? string.Format("    {0}: {1}", typeName, named.Name)
+                        : string.Format("    {0}", typeName);
+
+                    entries.Add(new KeyValuePair<string, string>(header, DescribeWeapon(component as WeaponAttributes)));
+                }
+
+                entries.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
+                foreach (var entry in entries)
+                {
+                    writer.WriteLine(entry.Key);
+                    if (entry.Value.Length > 0) { writer.Write(entry.Value); }
+                }
+            }
+        }
+    }
+}

--- a/Subsystem/EntityTypeDumper.cs
+++ b/Subsystem/EntityTypeDumper.cs
@@ -18,11 +18,20 @@ namespace Subsystem
         // For weapons, the interesting question is "what can this thing actually shoot, and does
         // it do so on its own" -- which is the auto-fire flags plus the per-target-class
         // modifiers, not the damage numbers.
-        private static string DescribeWeapon(WeaponAttributes weapon)
+        private static string DescribeWeapon(WeaponAttributes weapon, WeaponBinding[] loadout)
         {
             if (weapon == null) { return ""; }
 
             var sb = new StringBuilder();
+
+            // Commander buffs on UnitWeapon_* and WeaponRange_* key on the loadout's WeaponID,
+            // which is not always the weapon's own name -- the name above is what the
+            // "Entities" section keys on. Print both so they are not confused.
+            var weaponID = FindWeaponID(weapon, loadout);
+            if (weaponID != null)
+            {
+                sb.AppendFormat("        weapon ID (for commander buffs): {0}\n", weaponID);
+            }
 
             sb.AppendFormat("        auto-acquire: {0}   auto-fire: {1}   damage: {2}   cooldown: {3}ms\n",
                 weapon.ExcludeFromAutoTargetAcquisition ? "no" : "yes",
@@ -55,6 +64,21 @@ namespace Subsystem
             }
 
             return sb.ToString();
+        }
+
+        private static string FindWeaponID(WeaponAttributes weapon, WeaponBinding[] loadout)
+        {
+            if (loadout == null) { return null; }
+
+            foreach (var binding in loadout)
+            {
+                if (binding != null && binding.Weapon != null && binding.Weapon.Name == weapon.Name)
+                {
+                    return binding.WeaponID;
+                }
+            }
+
+            return null;
         }
 
         public static void Dump(EntityTypeCollection entityTypeCollection, TextWriter writer)
@@ -92,6 +116,9 @@ namespace Subsystem
                     continue;
                 }
 
+                var unitAttributes = entityType.Get<UnitAttributes>();
+                var loadout = unitAttributes != null ? unitAttributes.WeaponLoadout : null;
+
                 var entries = new List<KeyValuePair<string, string>>();
                 foreach (var component in components)
                 {
@@ -104,7 +131,7 @@ namespace Subsystem
                         ? string.Format("    {0}: {1}", typeName, named.Name)
                         : string.Format("    {0}", typeName);
 
-                    entries.Add(new KeyValuePair<string, string>(header, DescribeWeapon(component as WeaponAttributes)));
+                    entries.Add(new KeyValuePair<string, string>(header, DescribeWeapon(component as WeaponAttributes, loadout)));
                 }
 
                 entries.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));

--- a/Subsystem/EntityTypeDumper.cs
+++ b/Subsystem/EntityTypeDumper.cs
@@ -76,7 +76,10 @@ namespace Subsystem
 
             var sb = new StringBuilder();
 
-            sb.AppendFormat("        type: {0}", ability.AbilityType);
+            // TargetingType Passive is what makes UnitManager.ActivatePassiveAbilities fire an
+            // ability on spawn without the player casting it, so it is the flag that separates
+            // "heals by itself" from "there is a button somewhere".
+            sb.AppendFormat("        type: {0}   targeting: {1}", ability.AbilityType, ability.TargetingType);
 
             if (ability.Autocast != null && ability.Autocast.IsAutocastable)
             {

--- a/Subsystem/EntityTypeDumper.cs
+++ b/Subsystem/EntityTypeDumper.cs
@@ -66,6 +66,58 @@ namespace Subsystem
             return sb.ToString();
         }
 
+        // Regen, repair and the rest of the interesting abilities are all AbilityClass plus one
+        // populated sub-attribute, so the type alone does not tell you what an ability does.
+        // Passive self-repair, for instance, is ApplyStatusEffect + autocast-on-spawn pointing
+        // at a status effect whose modifier carries the heal rate.
+        private static string DescribeAbility(AbilityAttributes ability)
+        {
+            if (ability == null) { return ""; }
+
+            var sb = new StringBuilder();
+
+            sb.AppendFormat("        type: {0}", ability.AbilityType);
+
+            if (ability.Autocast != null && ability.Autocast.IsAutocastable)
+            {
+                sb.AppendFormat("   autocast: yes (on spawn: {0})", ability.Autocast.AutocastEnabledOnSpawn ? "yes" : "no");
+            }
+
+            if (ability.IsToggleable) { sb.Append("   toggleable"); }
+
+            sb.AppendFormat("   cooldown: {0}s   warmup: {1}s\n", ability.CooldownTimeSecs, ability.WarmupTimeSecs);
+
+            if (ability.Repair != null && !string.IsNullOrEmpty(ability.Repair.WeaponID))
+            {
+                sb.AppendFormat("        repairs with weapon ID: {0}\n", ability.Repair.WeaponID);
+            }
+
+            var apply = ability.ApplyStatusEffect;
+            if (apply == null || apply.StatusEffectsToApply == null) { return sb.ToString(); }
+
+            foreach (var effect in apply.StatusEffectsToApply)
+            {
+                if (effect == null) { continue; }
+
+                sb.AppendFormat("        applies status effect: {0}   lifetime: {1}   duration: {2}   maxStacks: {3}\n",
+                    effect.Name, effect.Lifetime, effect.Duration, effect.MaxStacks);
+
+                if (effect.Modifiers == null) { continue; }
+
+                foreach (var modifier in effect.Modifiers)
+                {
+                    var healthOverTime = modifier.HealthOverTimeAttributes;
+                    if (healthOverTime.Amount == 0) { continue; }
+
+                    sb.AppendFormat("            health over time: {0} per {1}ms, {2}, id \"{3}\"\n",
+                        healthOverTime.Amount, healthOverTime.MSTickDuration,
+                        healthOverTime.DamageType, healthOverTime.ID);
+                }
+            }
+
+            return sb.ToString();
+        }
+
         private static string FindWeaponID(WeaponAttributes weapon, WeaponBinding[] loadout)
         {
             if (loadout == null) { return null; }
@@ -131,7 +183,10 @@ namespace Subsystem
                         ? string.Format("    {0}: {1}", typeName, named.Name)
                         : string.Format("    {0}", typeName);
 
-                    entries.Add(new KeyValuePair<string, string>(header, DescribeWeapon(component as WeaponAttributes, loadout)));
+                    var detail = DescribeWeapon(component as WeaponAttributes, loadout)
+                               + DescribeAbility(component as AbilityAttributes);
+
+                    entries.Add(new KeyValuePair<string, string>(header, detail));
                 }
 
                 entries.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));

--- a/Subsystem/Patch/AbilityGrantPatch.cs
+++ b/Subsystem/Patch/AbilityGrantPatch.cs
@@ -1,0 +1,14 @@
+namespace Subsystem.Patch
+{
+    public class AbilityGrantPatch
+    {
+        // Entity type name of the ability to copy, e.g. "Ability_C_Battlecruiser_Regen".
+        // Subsystem.entities.log lists them, with what each one actually does.
+        public string From { get; set; }
+
+        // Leave a unit alone if it already regenerates -- that is, if any ability it has applies
+        // a healing health-over-time effect. Defaults to true, which is what you want for
+        // "give self-repair to everything that does not already have it".
+        public bool? SkipIfSelfHealing { get; set; }
+    }
+}

--- a/Subsystem/Patch/AttributesPatch.cs
+++ b/Subsystem/Patch/AttributesPatch.cs
@@ -5,5 +5,9 @@ namespace Subsystem.Patch
     public class AttributesPatch
     {
         public Dictionary<string, EntityTypePatch> Entities { get; set; } = new Dictionary<string, EntityTypePatch>();
+
+        // Keyed by commander ID. Applied by CommanderBuffLoader from a second hook, because the
+        // per-commander entity types do not exist yet when Entities is applied.
+        public Dictionary<string, CommanderPatch> Commanders { get; set; } = new Dictionary<string, CommanderPatch>();
     }
 }

--- a/Subsystem/Patch/CommanderPatch.cs
+++ b/Subsystem/Patch/CommanderPatch.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Subsystem.Patch
+{
+    public class CommanderPatch
+    {
+        public Dictionary<string, EntityTypeBuffPatch> EntityTypeBuffs { get; set; } = new Dictionary<string, EntityTypeBuffPatch>();
+    }
+}

--- a/Subsystem/Patch/CommanderPatch.cs
+++ b/Subsystem/Patch/CommanderPatch.cs
@@ -5,5 +5,7 @@ namespace Subsystem.Patch
     public class CommanderPatch
     {
         public Dictionary<string, EntityTypeBuffPatch> EntityTypeBuffs { get; set; } = new Dictionary<string, EntityTypeBuffPatch>();
+
+        public Dictionary<string, EntityTypeAbilityPatch> AddAbilities { get; set; } = new Dictionary<string, EntityTypeAbilityPatch>();
     }
 }

--- a/Subsystem/Patch/EntityTypeAbilityPatch.cs
+++ b/Subsystem/Patch/EntityTypeAbilityPatch.cs
@@ -1,0 +1,15 @@
+using BBI.Game.Data;
+using System.Collections.Generic;
+
+namespace Subsystem.Patch
+{
+    public class EntityTypeAbilityPatch
+    {
+        // Same matching as EntityTypeBuffPatch: name, or name prefix, narrowed by unit class.
+        public bool? UseAsPrefix { get; set; }
+        public UnitClass? UnitClass { get; set; }
+        public FlagOperator? ClassOperator { get; set; }
+
+        public Dictionary<string, AbilityGrantPatch> Abilities { get; set; } = new Dictionary<string, AbilityGrantPatch>();
+    }
+}

--- a/Subsystem/Patch/EntityTypeBuffPatch.cs
+++ b/Subsystem/Patch/EntityTypeBuffPatch.cs
@@ -1,0 +1,20 @@
+using BBI.Game.Data;
+using System.Collections.Generic;
+
+namespace Subsystem.Patch
+{
+    public class EntityTypeBuffPatch
+    {
+        // Match every entity type whose name starts with the key, instead of just the one type
+        // named by it. Same semantics as ModifyEntityTypeBuffCommand.
+        public bool? UseAsPrefix { get; set; }
+
+        // Optional extra filter on UnitAttributes.Class. None (the default) means no filter.
+        public UnitClass? UnitClass { get; set; }
+
+        // How UnitClass is matched: Or = shares any flag, And = has all of them.
+        public FlagOperator? ClassOperator { get; set; }
+
+        public Dictionary<string, AttributeBuffPatch> Buffs { get; set; } = new Dictionary<string, AttributeBuffPatch>();
+    }
+}

--- a/Subsystem/Subsystem.csproj
+++ b/Subsystem/Subsystem.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Reference Include="BBI.Core" />
     <Reference Include="BBI.Game.Data" />
+    <Reference Include="BBI.Game" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -90,6 +91,9 @@
     <Compile Include="Patch\WeaponAttributesPatch.cs" />
     <Compile Include="Wrappers\WeaponAttributesWrapper.cs" />
     <Compile Include="Wrappers\WeaponModifierInfoWrapper.cs" />
+    <Compile Include="CommanderBuffLoader.cs" />
+    <Compile Include="Patch\CommanderPatch.cs" />
+    <Compile Include="Patch\EntityTypeBuffPatch.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Subsystem/Subsystem.csproj
+++ b/Subsystem/Subsystem.csproj
@@ -94,6 +94,8 @@
     <Compile Include="CommanderBuffLoader.cs" />
     <Compile Include="Patch\CommanderPatch.cs" />
     <Compile Include="Patch\EntityTypeBuffPatch.cs" />
+    <Compile Include="Patch\EntityTypeAbilityPatch.cs" />
+    <Compile Include="Patch\AbilityGrantPatch.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Subsystem/Subsystem.csproj
+++ b/Subsystem/Subsystem.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Patch\WeaponModifierInfoPatch.cs" />
     <Compile Include="Wrappers\AbilityAttributesWrapper.cs" />
     <Compile Include="AttributeLoader.cs" />
+    <Compile Include="EntityTypeDumper.cs" />
     <Compile Include="Patch\AttributesPatch.cs" />
     <Compile Include="Wrappers\AttributeBuffSetWrapper.cs" />
     <Compile Include="Wrappers\AttributeBuffWrapper.cs" />

--- a/SubsystemLint/EntityNames.cs
+++ b/SubsystemLint/EntityNames.cs
@@ -1,0 +1,55 @@
+namespace SubsystemLint;
+
+/// <summary>
+/// The entity/component names from a Subsystem.entities.log, which the mod writes on every
+/// game start. Lines are either an entity name at column 0, or an indented "Type" /
+/// "Type: Name" component belonging to the entity above it.
+/// </summary>
+internal sealed class EntityNames
+{
+    private readonly Dictionary<string, HashSet<string>> _components = new(StringComparer.Ordinal);
+
+    public IEnumerable<string> Entities => _components.Keys;
+
+    public bool HasEntity(string entity) => _components.ContainsKey(entity);
+
+    public bool HasComponent(string entity, string component) =>
+        _components.TryGetValue(entity, out var set) && set.Contains(component);
+
+    public IEnumerable<string> ComponentsOf(string entity) =>
+        _components.TryGetValue(entity, out var set) ? set : [];
+
+    public static EntityNames Load(string path)
+    {
+        var names = new EntityNames();
+        string? current = null;
+
+        foreach (var raw in File.ReadLines(path))
+        {
+            if (raw.Length == 0 || raw.StartsWith('#')) continue;
+
+            if (!char.IsWhiteSpace(raw[0]))
+            {
+                current = raw.Trim();
+                if (current.Length > 0) names._components.TryAdd(current, new HashSet<string>(StringComparer.Ordinal));
+                continue;
+            }
+
+            if (current == null) continue;
+
+            // Components are indented exactly four spaces; anything deeper is per-component
+            // detail (weapon ranges, target-class modifiers) and is not a name.
+            if (raw.Length > 4 && raw[4] == ' ') continue;
+
+            // "    WeaponAttributes: C_HAC_Upgrade01_Weapon_G2A_MP" -> record the name part.
+            var line = raw.Trim();
+            var colon = line.IndexOf(':');
+            if (colon < 0) continue;
+
+            var componentName = line[(colon + 1)..].Trim();
+            if (componentName.Length > 0) names._components[current].Add(componentName);
+        }
+
+        return names;
+    }
+}

--- a/SubsystemLint/Program.cs
+++ b/SubsystemLint/Program.cs
@@ -64,7 +64,10 @@ internal static class Program
         try
         {
             doc = JsonDocument.Parse(File.ReadAllText(patchPath),
-                new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
+                // Match what the game's LitJson accepts, or this reports a clean bill of health
+                // on a file the game throws out. It skips // and /* */ comments, and it rejects
+                // a trailing comma with "Invalid token '125' in input string".
+                new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = false });
         }
         catch (JsonException e)
         {

--- a/SubsystemLint/Program.cs
+++ b/SubsystemLint/Program.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using GameLocator = SubsystemPatcher.GameLocator;
+
+namespace SubsystemLint;
+
+/// <summary>
+/// Checks a patch.json against the shapes Subsystem actually deserializes, and (optionally)
+/// against the entity/component names the installed game actually loaded.
+///
+/// Subsystem swallows almost everything that goes wrong: an unknown key is silently dropped by
+/// LitJson, and a name that does not exist is a line in Subsystem.log you have to go looking
+/// for. This reports both up front.
+/// </summary>
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        try { return Run(args); }
+        catch (Exception e) { Console.Error.WriteLine("error: " + e.Message); return 1; }
+    }
+
+    private static int Run(string[] args)
+    {
+        string? patchPath = null, managed = null, entities = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--managed" or "-m": managed = Next(args, ref i, "--managed"); break;
+                case "--entities" or "-e": entities = Next(args, ref i, "--entities"); break;
+                case "--help" or "-h": Usage(); return 0;
+                default:
+                    if (args[i].StartsWith('-')) throw new ArgumentException($"unknown argument: {args[i]}");
+                    patchPath = args[i];
+                    break;
+            }
+        }
+
+        managed ??= GameLocator.FindManagedDirectory()
+                    ?? throw new InvalidOperationException(
+                        "Could not find Data/Managed automatically; pass --managed <dir>.");
+        managed = Path.GetFullPath(managed);
+
+        var dataDir = Path.GetDirectoryName(managed)!;
+        patchPath ??= Path.Combine(dataDir, "patch.json");
+        entities ??= File.Exists(Path.Combine(dataDir, "Subsystem.entities.log"))
+            ? Path.Combine(dataDir, "Subsystem.entities.log")
+            : null;
+
+        if (!File.Exists(patchPath)) throw new FileNotFoundException($"patch file not found: {patchPath}");
+
+        var subsystemDll = Path.Combine(managed, "Subsystem.dll");
+        if (!File.Exists(subsystemDll))
+            throw new FileNotFoundException(
+                $"Subsystem.dll not found in {managed} — build it and copy it there first.");
+
+        Console.WriteLine($"patch    : {patchPath}");
+        Console.WriteLine($"schema   : {subsystemDll}");
+        Console.WriteLine($"names    : {entities ?? "(none — run the game once to produce Subsystem.entities.log)"}");
+        Console.WriteLine();
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(File.ReadAllText(patchPath),
+                new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
+        }
+        catch (JsonException e)
+        {
+            Console.Error.WriteLine($"FATAL: patch.json is not valid JSON — {e.Message}");
+            return 1;
+        }
+
+        var schema = new Schema(subsystemDll, managed);
+        var names = entities != null ? EntityNames.Load(entities) : null;
+        var report = new Report();
+
+        schema.Validate(doc.RootElement, "Subsystem.Patch.AttributesPatch", "", report, names);
+
+        report.Print();
+        return report.Errors > 0 ? 2 : 0;
+    }
+
+    private static string Next(string[] args, ref int i, string name)
+    {
+        if (++i >= args.Length) throw new ArgumentException($"{name} needs a value");
+        return args[i];
+    }
+
+    private static void Usage() => Console.WriteLine("""
+        SubsystemLint — validate a Deserts of Kharak patch.json before you launch the game.
+
+          SubsystemLint [patch.json] [options]
+
+          --managed,  -m <dir>   Path to Data/Managed (auto-detected if omitted)
+          --entities, -e <file>  Subsystem.entities.log, to check entity and component names
+          --help,     -h         This text
+
+        With no arguments it checks Data/patch.json next to the detected install, using
+        Data/Subsystem.entities.log for name checking if the game has written one.
+
+        Exit codes: 0 clean, 2 problems found, 1 could not run.
+        """);
+}

--- a/SubsystemLint/Report.cs
+++ b/SubsystemLint/Report.cs
@@ -1,0 +1,25 @@
+namespace SubsystemLint;
+
+internal sealed class Report
+{
+    private readonly List<(string Path, string Message)> _errors = [];
+    private readonly List<(string Path, string Message)> _notes = [];
+
+    public int Errors => _errors.Count;
+
+    public void Error(string path, string message) => _errors.Add((path, message));
+    public void Note(string path, string message) => _notes.Add((path, message));
+
+    public void Print()
+    {
+        foreach (var (path, message) in _errors)
+            Console.WriteLine($"ERROR  {path}\n       {message}\n");
+
+        foreach (var (path, message) in _notes)
+            Console.WriteLine($"note   {path}: {message}");
+
+        Console.WriteLine(_errors.Count == 0
+            ? "OK — no problems found."
+            : $"{_errors.Count} problem(s) found.");
+    }
+}

--- a/SubsystemLint/Schema.cs
+++ b/SubsystemLint/Schema.cs
@@ -42,6 +42,8 @@ internal sealed class Schema
         ["Subsystem.Patch.AttributesPatch.Commanders"] = KeyKind.CommanderId,
         ["Subsystem.Patch.CommanderPatch.EntityTypeBuffs"] = KeyKind.EntityOrPrefix,
         ["Subsystem.Patch.EntityTypeBuffPatch.Buffs"] = KeyKind.Index,
+        ["Subsystem.Patch.CommanderPatch.AddAbilities"] = KeyKind.EntityOrPrefix,
+        ["Subsystem.Patch.EntityTypeAbilityPatch.Abilities"] = KeyKind.Index,
     };
 
     public Schema(string subsystemDll, string managed)

--- a/SubsystemLint/Schema.cs
+++ b/SubsystemLint/Schema.cs
@@ -8,10 +8,14 @@ internal enum KeyKind
 {
     /// <summary>Entity type name, e.g. "C_HAC_Upgrade01_MP".</summary>
     Entity,
+    /// <summary>Entity type name, or a prefix of one when the entry sets "UseAsPrefix": true.</summary>
+    EntityOrPrefix,
     /// <summary>Name of a named component on the entity, e.g. a weapon.</summary>
     Component,
     /// <summary>Consecutive list index; AttributeLoader requires these to parse as integers.</summary>
     Index,
+    /// <summary>Commander ID; CommanderBuffLoader requires these to parse as integers.</summary>
+    CommanderId,
     /// <summary>Free-form identifier that cannot be checked statically.</summary>
     Free,
 }
@@ -35,6 +39,9 @@ internal sealed class Schema
         ["Subsystem.Patch.ExperienceLevelAttributesPatch.Buff"] = KeyKind.Index,
         ["Subsystem.Patch.WeaponAttributesPatch.Modifiers"] = KeyKind.Index,
         ["Subsystem.Patch.WeaponAttributesPatch.EntityTypesToSpawnOnImpact"] = KeyKind.Index,
+        ["Subsystem.Patch.AttributesPatch.Commanders"] = KeyKind.CommanderId,
+        ["Subsystem.Patch.CommanderPatch.EntityTypeBuffs"] = KeyKind.EntityOrPrefix,
+        ["Subsystem.Patch.EntityTypeBuffPatch.Buffs"] = KeyKind.Index,
     };
 
     public Schema(string subsystemDll, string managed)
@@ -163,6 +170,8 @@ internal sealed class Schema
         var kind = KeyKinds.TryGetValue(memberKey, out var k) ? k : KeyKind.Free;
         var valueType = dict.GenericArguments[1];
 
+        if (kind == KeyKind.Index) ReportIndexGaps(element, path, report);
+
         foreach (var entry in element.EnumerateObject())
         {
             var childPath = $"{path}.{entry.Name}";
@@ -188,6 +197,34 @@ internal sealed class Schema
                     }
                     break;
 
+                case KeyKind.CommanderId:
+                    if (!int.TryParse(entry.Name, out _))
+                        report.Error(childPath,
+                            $"'{entry.Name}' is not a commander ID; keys here are whole numbers "
+                            + "(Subsystem.log prints the local and CPU commander IDs at match start)");
+                    break;
+
+                case KeyKind.EntityOrPrefix:
+                    if (names == null) break;
+
+                    if (UsesPrefix(entry.Value))
+                    {
+                        if (!names.Entities.Any(e => e.StartsWith(entry.Name, StringComparison.Ordinal)))
+                            report.Error(childPath, $"no entity type in this install starts with '{entry.Name}'");
+                        break;
+                    }
+
+                    entity = entry.Name;
+                    if (!names.HasEntity(entry.Name))
+                    {
+                        var entityHint = Suggest(entry.Name, names.Entities);
+                        report.Error(childPath,
+                            $"no entity type named '{entry.Name}' in this install"
+                            + (entityHint != null ? $" — did you mean '{entityHint}'?" : "")
+                            + "  [add \"UseAsPrefix\": true to match a family of type names instead]");
+                    }
+                    break;
+
                 case KeyKind.Component:
                     if (names != null && entity != null && names.HasEntity(entity)
                         && !names.HasComponent(entity, entry.Name))
@@ -203,6 +240,37 @@ internal sealed class Schema
             ValidateValue(entry.Value, valueType, childPath, report, names, entity, memberKey);
         }
     }
+
+    /// <summary>
+    /// An indexed list has to be exactly 0..n-1. AttributeLoader walks the entries in index
+    /// order and stops at the first index past the end of the list, so a gap silently discards
+    /// every later entry rather than reporting anything.
+    /// </summary>
+    private static void ReportIndexGaps(JsonElement element, string path, Report report)
+    {
+        var indices = new List<int>();
+        foreach (var entry in element.EnumerateObject())
+        {
+            if (int.TryParse(entry.Name, out var i)) indices.Add(i);
+        }
+
+        if (indices.Count == 0) return;
+
+        indices.Sort();
+        var expected = Enumerable.Range(0, indices.Count).ToList();
+        if (indices.SequenceEqual(expected)) return;
+
+        var missing = expected.Except(indices).ToList();
+        report.Error(path,
+            $"indices must be 0..{indices.Count - 1} with no gaps, found {string.Join(", ", indices)}"
+            + (missing.Count > 0 ? $" — missing {string.Join(", ", missing)}" : "")
+            + "  [AttributeLoader stops at the first gap and drops every entry after it]");
+    }
+
+    private static bool UsesPrefix(JsonElement value) =>
+        value.ValueKind == JsonValueKind.Object
+        && value.TryGetProperty("UseAsPrefix", out var flag)
+        && flag.ValueKind == JsonValueKind.True;
 
     private static void ValidateEnum(JsonElement element, TypeDefinition def, string path, Report report)
     {

--- a/SubsystemLint/Schema.cs
+++ b/SubsystemLint/Schema.cs
@@ -1,0 +1,294 @@
+using Mono.Cecil;
+using System.Text.Json;
+
+namespace SubsystemLint;
+
+/// <summary>How a Dictionary&lt;string, T&gt; key in the patch model is interpreted.</summary>
+internal enum KeyKind
+{
+    /// <summary>Entity type name, e.g. "C_HAC_Upgrade01_MP".</summary>
+    Entity,
+    /// <summary>Name of a named component on the entity, e.g. a weapon.</summary>
+    Component,
+    /// <summary>Consecutive list index; AttributeLoader requires these to parse as integers.</summary>
+    Index,
+    /// <summary>Free-form identifier that cannot be checked statically.</summary>
+    Free,
+}
+
+internal sealed class Schema
+{
+    private readonly AssemblyDefinition _subsystem;
+    private readonly Dictionary<string, TypeDefinition> _types = new(StringComparer.Ordinal);
+
+    // Which dictionaries are keyed by a name and which by a list index. AttributeLoader's
+    // applyListPatch requires integer keys; the rest key on names in the game data.
+    private static readonly Dictionary<string, KeyKind> KeyKinds = new(StringComparer.Ordinal)
+    {
+        ["Subsystem.Patch.AttributesPatch.Entities"] = KeyKind.Entity,
+        ["Subsystem.Patch.EntityTypePatch.AbilityAttributes"] = KeyKind.Component,
+        ["Subsystem.Patch.EntityTypePatch.StorageAttributes"] = KeyKind.Component,
+        ["Subsystem.Patch.EntityTypePatch.WeaponAttributes"] = KeyKind.Component,
+        ["Subsystem.Patch.UnitHangarAttributesPatch.HangarBays"] = KeyKind.Component,
+        ["Subsystem.Patch.StorageAttributesPatch.InventoryLoadout"] = KeyKind.Free,
+        ["Subsystem.Patch.ExperienceAttributesPatch.Levels"] = KeyKind.Index,
+        ["Subsystem.Patch.ExperienceLevelAttributesPatch.Buff"] = KeyKind.Index,
+        ["Subsystem.Patch.WeaponAttributesPatch.Modifiers"] = KeyKind.Index,
+        ["Subsystem.Patch.WeaponAttributesPatch.EntityTypesToSpawnOnImpact"] = KeyKind.Index,
+    };
+
+    public Schema(string subsystemDll, string managed)
+    {
+        var resolver = new DefaultAssemblyResolver();
+        resolver.RemoveSearchDirectory(".");
+        resolver.AddSearchDirectory(managed);
+        _subsystem = AssemblyDefinition.ReadAssembly(
+            subsystemDll, new ReaderParameters { AssemblyResolver = resolver });
+
+        foreach (var t in _subsystem.MainModule.GetTypes())
+            _types[t.FullName] = t;
+    }
+
+    public void Validate(JsonElement element, string typeName, string path, Report report, EntityNames? names)
+        => ValidateType(element, Resolve(typeName), path, report, names, currentEntity: null);
+
+    private TypeDefinition Resolve(string fullName) =>
+        _types.TryGetValue(fullName, out var t)
+            ? t
+            : throw new InvalidOperationException($"type not found in Subsystem.dll: {fullName}");
+
+    private void ValidateType(JsonElement element, TypeDefinition type, string path,
+                              Report report, EntityNames? names, string? currentEntity)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            report.Error(path, $"expected an object for {type.Name}, found {Describe(element)}");
+            return;
+        }
+
+        var properties = type.Properties
+            .Where(p => p.GetMethod is { IsPublic: true } && p.SetMethod is { IsPublic: true })
+            .ToDictionary(p => p.Name, StringComparer.Ordinal);
+
+        foreach (var member in element.EnumerateObject())
+        {
+            var childPath = path.Length == 0 ? member.Name : $"{path}.{member.Name}";
+
+            if (!properties.TryGetValue(member.Name, out var prop))
+            {
+                var hint = Suggest(member.Name, properties.Keys);
+                report.Error(childPath,
+                    $"'{member.Name}' is not a property of {type.Name}"
+                    + (hint != null ? $" — did you mean '{hint}'?" : "")
+                    + "  [this makes LitJson throw, so the WHOLE patch is discarded]");
+                continue;
+            }
+
+            ValidateValue(member.Value, prop.PropertyType, childPath, report, names, currentEntity,
+                          $"{type.FullName}.{prop.Name}");
+        }
+    }
+
+    private void ValidateValue(JsonElement element, TypeReference typeRef, string path,
+                               Report report, EntityNames? names, string? currentEntity, string memberKey)
+    {
+        // Nullable<T> — every scalar in the patch model is one of these.
+        if (typeRef is GenericInstanceType { Name: "Nullable`1" } nullable)
+        {
+            if (element.ValueKind == JsonValueKind.Null) return;
+            ValidateValue(element, nullable.GenericArguments[0], path, report, names, currentEntity, memberKey);
+            return;
+        }
+
+        if (typeRef is GenericInstanceType { Name: "Dictionary`2" } dict)
+        {
+            ValidateDictionary(element, dict, path, report, names, currentEntity, memberKey);
+            return;
+        }
+
+        switch (typeRef.FullName)
+        {
+            case "System.String":
+                Expect(element, JsonValueKind.String, path, report, "a string");
+                return;
+            case "System.Boolean":
+                if (element.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+                    report.Error(path, $"expected true/false, found {Describe(element)}");
+                return;
+            case "System.Int32":
+                if (element.ValueKind != JsonValueKind.Number) { report.Error(path, $"expected a whole number, found {Describe(element)}"); return; }
+                if (!element.TryGetInt32(out _))
+                    report.Error(path, $"expected a whole number that fits in an int, found {element.GetRawText()}");
+                return;
+            case "System.Double" or "System.Single":
+                if (element.ValueKind != JsonValueKind.Number)
+                    report.Error(path, $"expected a number, found {Describe(element)}");
+                return;
+        }
+
+        var def = SafeResolve(typeRef);
+
+        if (def is { IsEnum: true })
+        {
+            ValidateEnum(element, def, path, report);
+            return;
+        }
+
+        // string[] / IEnumerable<string> — e.g. Dependencies, ThreatCounters.
+        if (typeRef is ArrayType || typeRef is GenericInstanceType { Name: "IEnumerable`1" or "List`1" })
+        {
+            if (element.ValueKind != JsonValueKind.Array)
+                report.Error(path, $"expected an array, found {Describe(element)}");
+            return;
+        }
+
+        if (def != null && def.FullName.StartsWith("Subsystem.Patch.", StringComparison.Ordinal))
+        {
+            ValidateType(element, def, path, report, names, currentEntity);
+            return;
+        }
+
+        report.Note(path, $"not checked (type {typeRef.FullName})");
+    }
+
+    private void ValidateDictionary(JsonElement element, GenericInstanceType dict, string path,
+                                    Report report, EntityNames? names, string? currentEntity, string memberKey)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            report.Error(path, $"expected an object of named entries, found {Describe(element)}");
+            return;
+        }
+
+        var kind = KeyKinds.TryGetValue(memberKey, out var k) ? k : KeyKind.Free;
+        var valueType = dict.GenericArguments[1];
+
+        foreach (var entry in element.EnumerateObject())
+        {
+            var childPath = $"{path}.{entry.Name}";
+            var entity = currentEntity;
+
+            switch (kind)
+            {
+                case KeyKind.Index:
+                    if (!int.TryParse(entry.Name, out _))
+                        report.Error(childPath,
+                            $"'{entry.Name}' must be a list index (\"0\", \"1\", ...); "
+                            + "AttributeLoader stops processing this list otherwise");
+                    break;
+
+                case KeyKind.Entity:
+                    entity = entry.Name;
+                    if (names != null && !names.HasEntity(entry.Name))
+                    {
+                        var hint = Suggest(entry.Name, names.Entities);
+                        report.Error(childPath,
+                            $"no entity type named '{entry.Name}' in this install"
+                            + (hint != null ? $" — did you mean '{hint}'?" : ""));
+                    }
+                    break;
+
+                case KeyKind.Component:
+                    if (names != null && entity != null && names.HasEntity(entity)
+                        && !names.HasComponent(entity, entry.Name))
+                    {
+                        var hint = Suggest(entry.Name, names.ComponentsOf(entity));
+                        report.Error(childPath,
+                            $"'{entity}' has no component named '{entry.Name}'"
+                            + (hint != null ? $" — did you mean '{hint}'?" : ""));
+                    }
+                    break;
+            }
+
+            ValidateValue(entry.Value, valueType, childPath, report, names, entity, memberKey);
+        }
+    }
+
+    private static void ValidateEnum(JsonElement element, TypeDefinition def, string path, Report report)
+    {
+        var members = def.Fields.Where(f => f.IsStatic && f.IsLiteral).Select(f => f.Name).ToList();
+
+        if (element.ValueKind == JsonValueKind.Number) return; // numeric enum values are legal
+
+        if (element.ValueKind != JsonValueKind.String)
+        {
+            report.Error(path, $"expected one of {string.Join(", ", members)}, found {Describe(element)}");
+            return;
+        }
+
+        var raw = element.GetString() ?? "";
+        var isFlags = def.CustomAttributes.Any(a => a.AttributeType.Name == "FlagsAttribute");
+
+        // [Flags] enums accept "A, B" per the README.
+        var parts = isFlags
+            ? raw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            : [raw];
+
+        foreach (var part in parts)
+        {
+            if (members.Contains(part, StringComparer.Ordinal)) continue;
+            var hint = Suggest(part, members);
+            report.Error(path,
+                $"'{part}' is not a valid {def.Name} value"
+                + (hint != null ? $" — did you mean '{hint}'?" : $" (valid: {string.Join(", ", members)})"));
+        }
+
+        if (!isFlags && raw.Contains(','))
+            report.Error(path, $"{def.Name} is not a [Flags] enum, so it takes a single value");
+    }
+
+    private static void Expect(JsonElement e, JsonValueKind kind, string path, Report report, string what)
+    {
+        if (e.ValueKind != kind) report.Error(path, $"expected {what}, found {Describe(e)}");
+    }
+
+    private static string Describe(JsonElement e) => e.ValueKind switch
+    {
+        JsonValueKind.Object => "an object",
+        JsonValueKind.Array => "an array",
+        JsonValueKind.String => $"the string {e.GetRawText()}",
+        JsonValueKind.Number => $"the number {e.GetRawText()}",
+        JsonValueKind.True or JsonValueKind.False => $"the boolean {e.GetRawText()}",
+        _ => "null",
+    };
+
+    private static TypeDefinition? SafeResolve(TypeReference r)
+    {
+        try { return r.Resolve(); } catch { return null; }
+    }
+
+    /// <summary>Closest candidate by edit distance, when it is close enough to be worth suggesting.</summary>
+    internal static string? Suggest(string value, IEnumerable<string> candidates)
+    {
+        string? best = null;
+        var bestDistance = int.MaxValue;
+
+        foreach (var c in candidates)
+        {
+            var d = Distance(value, c);
+            if (d < bestDistance) { bestDistance = d; best = c; }
+        }
+
+        var threshold = Math.Max(2, value.Length / 3);
+        return bestDistance <= threshold ? best : null;
+    }
+
+    private static int Distance(string a, string b)
+    {
+        var previous = new int[b.Length + 1];
+        var current = new int[b.Length + 1];
+        for (var j = 0; j <= b.Length; j++) previous[j] = j;
+
+        for (var i = 1; i <= a.Length; i++)
+        {
+            current[0] = i;
+            for (var j = 1; j <= b.Length; j++)
+            {
+                var cost = char.ToLowerInvariant(a[i - 1]) == char.ToLowerInvariant(b[j - 1]) ? 0 : 1;
+                current[j] = Math.Min(Math.Min(current[j - 1] + 1, previous[j] + 1), previous[j - 1] + cost);
+            }
+            (previous, current) = (current, previous);
+        }
+        return previous[b.Length];
+    }
+}

--- a/SubsystemLint/SubsystemLint.csproj
+++ b/SubsystemLint/SubsystemLint.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>SubsystemLint</AssemblyName>
+    <RootNamespace>SubsystemLint</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Same install-detection logic as the patcher; kept in one place. -->
+    <Compile Include="../SubsystemPatcher/GameLocator.cs" Link="GameLocator.cs" />
+  </ItemGroup>
+
+</Project>

--- a/SubsystemPatcher/GameLocator.cs
+++ b/SubsystemPatcher/GameLocator.cs
@@ -1,0 +1,87 @@
+using System.Text.RegularExpressions;
+
+namespace SubsystemPatcher;
+
+/// <summary>
+/// Best-effort discovery of the game's Data/Managed folder across the places Steam
+/// installs it on Linux (native, Flatpak, Snap) and Windows.
+/// </summary>
+internal static partial class GameLocator
+{
+    private const string GameFolder = "Deserts of Kharak";
+    private static readonly string[] ManagedTail = ["Data", "Managed"];
+
+    public static string? FindManagedDirectory()
+    {
+        foreach (var steam in SteamRoots())
+        {
+            foreach (var library in LibraryFolders(steam))
+            {
+                var managed = Path.Combine(
+                    new[] { library, "steamapps", "common", GameFolder }.Concat(ManagedTail).ToArray());
+
+                if (File.Exists(Path.Combine(managed, "BBI.Unity.Game.dll")))
+                    return managed;
+            }
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> SteamRoots()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        var candidates = new List<string>
+        {
+            // Flatpak Steam — where this shows up on an immutable Fedora / Bazzite style install.
+            Path.Combine(home, ".var", "app", "com.valvesoftware.Steam", "data", "Steam"),
+            Path.Combine(home, ".steam", "steam"),
+            Path.Combine(home, ".steam", "root"),
+            Path.Combine(home, ".local", "share", "Steam"),
+            Path.Combine(home, "snap", "steam", "common", ".local", "share", "Steam"),
+            // macOS
+            Path.Combine(home, "Library", "Application Support", "Steam"),
+        };
+
+        if (OperatingSystem.IsWindows())
+        {
+            candidates.Add(@"C:\Program Files (x86)\Steam");
+            candidates.Add(@"C:\Program Files\Steam");
+            foreach (var drive in DriveInfo.GetDrives())
+                candidates.Add(Path.Combine(drive.Name, "Steam"));
+        }
+
+        return candidates.Where(Directory.Exists).Distinct();
+    }
+
+    /// <summary>
+    /// A Steam root plus every extra library declared in libraryfolders.vdf, so installs on a
+    /// second drive are found too.
+    /// </summary>
+    private static IEnumerable<string> LibraryFolders(string steamRoot)
+    {
+        yield return steamRoot;
+
+        foreach (var vdf in new[]
+                 {
+                     Path.Combine(steamRoot, "steamapps", "libraryfolders.vdf"),
+                     Path.Combine(steamRoot, "config", "libraryfolders.vdf"),
+                 })
+        {
+            if (!File.Exists(vdf)) continue;
+
+            string text;
+            try { text = File.ReadAllText(vdf); }
+            catch { continue; }
+
+            foreach (Match m in PathEntry().Matches(text))
+            {
+                var p = m.Groups[1].Value.Replace(@"\\", @"\");
+                if (Directory.Exists(p)) yield return p;
+            }
+        }
+    }
+
+    [GeneratedRegex("\"path\"\\s*\"([^\"]+)\"")]
+    private static partial Regex PathEntry();
+}

--- a/SubsystemPatcher/Program.cs
+++ b/SubsystemPatcher/Program.cs
@@ -1,0 +1,370 @@
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace SubsystemPatcher;
+
+/// <summary>
+/// Injects the Subsystem hook into the game's own BBI.Unity.Game.dll.
+///
+/// Subsystem 0.4.0 shipped a pre-patched copy of BBI.Unity.Game.dll built against the
+/// November 2018 game. Dropping that file into a current install replaces the entire game
+/// assembly with an eight-year-old one, which is why the game dies on the way from the
+/// menu into a match. The hook itself is three IL instructions; this tool applies those
+/// three instructions to whatever BBI.Unity.Game.dll the player actually has.
+/// </summary>
+internal static class Program
+{
+    private const string TargetAssembly = "BBI.Unity.Game.dll";
+    private const string ModAssembly = "Subsystem.dll";
+    private const string BackupSuffix = ".subsystem-backup";
+
+    private const string HookTypeName = "BBI.Unity.Game.ShipbreakersMain";
+    private const string HookMethodName = "ResetEntityManager";
+    private const string AnchorMethodName = "InitializeEntityManager";
+    private const string EntityTypesFieldName = "sEntityTypes";
+
+    private const string LoaderTypeName = "Subsystem.AttributeLoader";
+    private const string LoaderMethodName = "LoadAttributes";
+
+    private static int Main(string[] args)
+    {
+        try
+        {
+            return Run(args);
+        }
+        catch (Exception e)
+        {
+            Error(e.Message);
+            return 1;
+        }
+    }
+
+    private static int Run(string[] args)
+    {
+        string? managed = null;
+        var mode = Mode.Patch;
+        var force = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--managed" or "-m":
+                    if (++i >= args.Length) throw new ArgumentException("--managed needs a directory");
+                    managed = args[i];
+                    break;
+                case "--verify" or "-v": mode = Mode.Verify; break;
+                case "--restore" or "-r": mode = Mode.Restore; break;
+                case "--force" or "-f": force = true; break;
+                case "--help" or "-h": Usage(); return 0;
+                default: throw new ArgumentException($"unknown argument: {args[i]}");
+            }
+        }
+
+        managed ??= GameLocator.FindManagedDirectory()
+                    ?? throw new InvalidOperationException(
+                        "Could not find the game's Data/Managed folder automatically. "
+                        + "Pass it explicitly:  --managed \"<...>/Deserts of Kharak/Data/Managed\"");
+
+        managed = Path.GetFullPath(managed);
+        var target = Path.Combine(managed, TargetAssembly);
+
+        if (!File.Exists(target))
+            throw new FileNotFoundException($"{TargetAssembly} not found in {managed}");
+
+        Info($"Managed folder: {managed}");
+
+        return mode switch
+        {
+            Mode.Verify => Verify(managed, target),
+            Mode.Restore => Restore(target),
+            _ => Patch(managed, target, force),
+        };
+    }
+
+    private enum Mode { Patch, Verify, Restore }
+
+    // ---------------------------------------------------------------- patch
+
+    private static int Patch(string managed, string target, bool force)
+    {
+        var mod = Path.Combine(managed, ModAssembly);
+        if (!File.Exists(mod))
+        {
+            var bundled = FindBundledSubsystemDll();
+            if (bundled == null)
+                throw new FileNotFoundException(
+                    $"{ModAssembly} is not in {managed}. Copy Subsystem.dll there first "
+                    + "(from the 0.4.0 release zip, or from Subsystem/bin/Release after building it).");
+
+            File.Copy(bundled, mod);
+            Info($"Copied {ModAssembly} into the Managed folder.");
+        }
+
+        var stale = CountDanglingReferences(target, managed);
+        if (stale > 0)
+        {
+            Error($"{TargetAssembly} does not match the rest of this install "
+                  + $"({stale} references into the other game assemblies do not resolve).");
+            Error("");
+            Error("That is what the old install instructions produce: the 0.4.0 zip contains a whole");
+            Error("BBI.Unity.Game.dll built against the 2018 game, and dropping it in replaces eight");
+            Error("years of game code. Restore the real file first, then re-run this tool:");
+            Error("");
+            Error($"  - if {Path.GetFileName(target + BackupSuffix)} exists, run with --restore, or");
+            Error("  - in Steam: right-click the game > Properties > Installed Files > Verify integrity.");
+            return 1;
+        }
+
+        if (IsPatched(target, managed) && !force)
+        {
+            Info("BBI.Unity.Game.dll already contains the Subsystem hook. Nothing to do.");
+            Info("(Use --force to re-apply, or --restore to remove it.)");
+            return 0;
+        }
+
+        var backup = target + BackupSuffix;
+
+        // Always patch a pristine assembly: if a backup exists it is the unpatched original,
+        // so re-patching after a game update means starting from the *new* file, not the backup.
+        string source;
+        if (IsPatched(target, managed))
+        {
+            if (!File.Exists(backup))
+                throw new InvalidOperationException(
+                    "BBI.Unity.Game.dll is already patched but no backup exists. "
+                    + "Verify your game files through Steam, then run this tool again.");
+            source = backup;
+            Info("Re-applying hook from the pristine backup.");
+        }
+        else
+        {
+            source = target;
+            if (!File.Exists(backup))
+            {
+                File.Copy(target, backup);
+                Info($"Backed up original to {Path.GetFileName(backup)}");
+            }
+            else
+            {
+                Info($"Backup already exists ({Path.GetFileName(backup)}); refreshing it from the current file.");
+                File.Copy(target, backup, overwrite: true);
+            }
+        }
+
+        var temp = target + ".tmp";
+
+        using (var resolver = new DefaultAssemblyResolver())
+        {
+            resolver.RemoveSearchDirectory(".");
+            resolver.AddSearchDirectory(managed);
+
+            using var game = AssemblyDefinition.ReadAssembly(
+                source, new ReaderParameters { AssemblyResolver = resolver });
+            using var subsystem = AssemblyDefinition.ReadAssembly(
+                Path.Combine(managed, ModAssembly), new ReaderParameters { AssemblyResolver = resolver });
+
+            InjectHook(game, subsystem);
+            game.Write(temp);
+        }
+
+        File.Move(temp, target, overwrite: true);
+        Info("Patched BBI.Unity.Game.dll.");
+
+        if (!IsPatched(target, managed))
+            throw new InvalidOperationException("Post-patch verification failed — the hook is not present.");
+
+        Info("Verified: the Subsystem hook is present.");
+        Info("");
+        Info("Put your patch.json in the Data folder (one level up from Managed) and start a match.");
+        Info("Subsystem.log will appear next to it.");
+        return 0;
+    }
+
+    private static void InjectHook(AssemblyDefinition game, AssemblyDefinition subsystem)
+    {
+        var hookType = game.MainModule.GetType(HookTypeName)
+            ?? throw new InvalidOperationException($"{HookTypeName} not found — is this really BBI.Unity.Game.dll?");
+
+        var hookMethod = hookType.Methods.FirstOrDefault(m => m.Name == HookMethodName && m.Parameters.Count == 0)
+            ?? throw new InvalidOperationException(
+                $"{HookTypeName}::{HookMethodName}() not found. The game's code changed shape; "
+                + "the hook site needs to be re-identified.");
+
+        if (!hookMethod.HasBody)
+            throw new InvalidOperationException($"{HookMethodName} has no body.");
+
+        var entityTypesField = hookType.Fields.FirstOrDefault(f => f.Name == EntityTypesFieldName && f.IsStatic)
+            ?? throw new InvalidOperationException($"static field {EntityTypesFieldName} not found on {HookTypeName}.");
+
+        var loaderType = subsystem.MainModule.GetType(LoaderTypeName)
+            ?? throw new InvalidOperationException($"{LoaderTypeName} not found in {ModAssembly}.");
+
+        var loaderCtor = loaderType.Methods.FirstOrDefault(m => m.IsConstructor && m.Parameters.Count == 0)
+            ?? throw new InvalidOperationException($"{LoaderTypeName} has no parameterless constructor.");
+
+        var loadAttributes = loaderType.Methods.FirstOrDefault(
+                m => m.Name == LoaderMethodName
+                     && m.Parameters.Count == 1
+                     && m.Parameters[0].ParameterType.FullName == entityTypesField.FieldType.FullName)
+            ?? throw new InvalidOperationException(
+                $"{LoaderTypeName}::{LoaderMethodName}({entityTypesField.FieldType.FullName}) not found.");
+
+        var il = hookMethod.Body.GetILProcessor();
+
+        // The original 0.4.0 patch appended the call after ResetEntityManager rebuilds the
+        // collection via InitializeEntityManager, so anchor on that call rather than on a
+        // raw instruction offset.
+        var anchor = hookMethod.Body.Instructions.LastOrDefault(
+                i => (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+                     && i.Operand is MethodReference mr
+                     && mr.Name == AnchorMethodName)
+            ?? throw new InvalidOperationException(
+                $"no call to {AnchorMethodName} inside {HookMethodName} — hook site needs re-identifying.");
+
+        var ctorRef = game.MainModule.ImportReference(loaderCtor);
+        var loadRef = game.MainModule.ImportReference(loadAttributes);
+
+        // newobj  Subsystem.AttributeLoader::.ctor()
+        // ldsfld  ShipbreakersMain::sEntityTypes
+        // call    Subsystem.AttributeLoader::LoadAttributes(EntityTypeCollection)
+        var call = Instruction.Create(OpCodes.Call, loadRef);
+        var load = Instruction.Create(OpCodes.Ldsfld, entityTypesField);
+        var make = Instruction.Create(OpCodes.Newobj, ctorRef);
+
+        il.InsertAfter(anchor, call);
+        il.InsertAfter(anchor, load);
+        il.InsertAfter(anchor, make);
+
+        Info($"Injected hook into {HookTypeName}::{HookMethodName} after the {AnchorMethodName} call.");
+    }
+
+    // --------------------------------------------------------------- verify
+
+    private static int Verify(string managed, string target)
+    {
+        var patched = IsPatched(target, managed);
+        var mod = File.Exists(Path.Combine(managed, ModAssembly));
+        var backup = File.Exists(target + BackupSuffix);
+        var stale = CountDanglingReferences(target, managed);
+
+        Info($"{TargetAssembly} hooked : {(patched ? "yes" : "no")}");
+        Info($"{ModAssembly} present   : {(mod ? "yes" : "no")}");
+        Info($"backup present          : {(backup ? "yes" : "no")}");
+        Info($"matches this install    : {(stale == 0 ? "yes" : $"NO — {stale} dangling references")}");
+
+        if (stale > 0)
+        {
+            Error("This BBI.Unity.Game.dll was built against a different version of the game. "
+                  + "Restore it (--restore, or verify the game files in Steam) before playing.");
+            return 3;
+        }
+
+        if (patched && mod) { Info("Subsystem is installed."); return 0; }
+        Info("Subsystem is NOT fully installed. Run this tool with no arguments to install it.");
+        return 2;
+    }
+
+    /// <summary>
+    /// Counts type references in <paramref name="target"/> that no longer resolve against the
+    /// other assemblies in the Managed folder. A healthy BBI.Unity.Game.dll scores zero; the
+    /// 2018 copy shipped in the release zip scores high, because it was built against a
+    /// different BBI.Game / BBI.Core / BBI.Unity.Core.
+    /// </summary>
+    private static int CountDanglingReferences(string target, string managed)
+    {
+        using var resolver = new DefaultAssemblyResolver();
+        resolver.RemoveSearchDirectory(".");
+        resolver.AddSearchDirectory(managed);
+        using var asm = AssemblyDefinition.ReadAssembly(
+            target, new ReaderParameters { AssemblyResolver = resolver });
+
+        var dangling = 0;
+        foreach (var t in asm.MainModule.GetTypeReferences())
+        {
+            // Only judge references into the game's own assemblies. Subsystem.dll may
+            // legitimately be absent at this point, and BCL drift is not our concern.
+            var scope = t.Scope?.Name ?? "";
+            if (!scope.StartsWith("BBI.")) continue;
+            try { if (t.Resolve() == null) dangling++; }
+            catch { dangling++; }
+        }
+        return dangling;
+    }
+
+    private static bool IsPatched(string target, string managed)
+    {
+        using var resolver = new DefaultAssemblyResolver();
+        resolver.RemoveSearchDirectory(".");
+        resolver.AddSearchDirectory(managed);
+        using var asm = AssemblyDefinition.ReadAssembly(
+            target, new ReaderParameters { AssemblyResolver = resolver });
+
+        var type = asm.MainModule.GetType(HookTypeName);
+        var method = type?.Methods.FirstOrDefault(m => m.Name == HookMethodName && m.Parameters.Count == 0);
+        if (method is not { HasBody: true }) return false;
+
+        return method.Body.Instructions.Any(
+            i => i.Operand is MethodReference mr
+                 && mr.Name == LoaderMethodName
+                 && mr.DeclaringType?.FullName == LoaderTypeName);
+    }
+
+    // -------------------------------------------------------------- restore
+
+    private static int Restore(string target)
+    {
+        var backup = target + BackupSuffix;
+        if (!File.Exists(backup))
+        {
+            Error($"No backup found at {backup}. Verify the game files through Steam to restore the original.");
+            return 1;
+        }
+
+        File.Copy(backup, target, overwrite: true);
+        Info("Restored the original BBI.Unity.Game.dll from backup.");
+        Info($"(Subsystem.dll was left in place; delete it and {Path.GetFileName(backup)} if you want a clean install.)");
+        return 0;
+    }
+
+    // --------------------------------------------------------------- helpers
+
+    private static string? FindBundledSubsystemDll()
+    {
+        var probes = new[]
+        {
+            AppContext.BaseDirectory,
+            Directory.GetCurrentDirectory(),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Subsystem", "bin", "Release"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Subsystem", "bin", "Debug"),
+        };
+
+        foreach (var p in probes)
+        {
+            var candidate = Path.Combine(p, ModAssembly);
+            if (File.Exists(candidate)) return Path.GetFullPath(candidate);
+        }
+        return null;
+    }
+
+    private static void Usage()
+    {
+        Console.WriteLine("""
+            SubsystemPatcher — installs the Subsystem mod loader into Homeworld: Deserts of Kharak
+            by patching the game's own BBI.Unity.Game.dll instead of replacing it.
+
+              SubsystemPatcher [options]
+
+              --managed, -m <dir>   Path to "Deserts of Kharak/Data/Managed" (auto-detected if omitted)
+              --verify,  -v         Report whether the hook and Subsystem.dll are installed
+              --restore, -r         Restore the original BBI.Unity.Game.dll from the backup
+              --force,   -f         Re-apply the hook even if it is already present
+              --help,    -h         This text
+
+            Re-run after every game update: Steam replaces BBI.Unity.Game.dll and removes the hook.
+            """);
+    }
+
+    private static void Info(string m) => Console.WriteLine(m);
+    private static void Error(string m) => Console.Error.WriteLine("error: " + m);
+}

--- a/SubsystemPatcher/Program.cs
+++ b/SubsystemPatcher/Program.cs
@@ -26,6 +26,13 @@ internal static class Program
     private const string LoaderTypeName = "Subsystem.AttributeLoader";
     private const string LoaderMethodName = "LoadAttributes";
 
+    // Second hook, for the per-commander section of patch.json. The per-commander entity types
+    // do not exist until Sim's constructor has run, so this has to be applied later than the
+    // first hook: inside the OnSceneLoadComplete coroutine, right after SimController.PostLoadInit.
+    private const string BuffAnchorMethodName = "PostLoadInit";
+    private const string BuffLoaderTypeName = "Subsystem.CommanderBuffLoader";
+    private const string BuffLoaderMethodName = "ApplyCommanderBuffs";
+
     private static int Main(string[] args)
     {
         try
@@ -116,26 +123,31 @@ internal static class Program
             return 1;
         }
 
-        if (IsPatched(target, managed) && !force)
+        var hooks = FindHooks(target, managed);
+
+        if (hooks.All && !force)
         {
-            Info("BBI.Unity.Game.dll already contains the Subsystem hook. Nothing to do.");
-            Info("(Use --force to re-apply, or --restore to remove it.)");
+            Info("BBI.Unity.Game.dll already contains both Subsystem hooks. Nothing to do.");
+            Info("(Use --force to re-apply, or --restore to remove them.)");
             return 0;
         }
+
+        if (hooks.Any && !hooks.All)
+            Info("An older Subsystem hook is present; re-patching to add the commander-buff hook.");
 
         var backup = target + BackupSuffix;
 
         // Always patch a pristine assembly: if a backup exists it is the unpatched original,
         // so re-patching after a game update means starting from the *new* file, not the backup.
         string source;
-        if (IsPatched(target, managed))
+        if (hooks.Any)
         {
             if (!File.Exists(backup))
                 throw new InvalidOperationException(
                     "BBI.Unity.Game.dll is already patched but no backup exists. "
                     + "Verify your game files through Steam, then run this tool again.");
             source = backup;
-            Info("Re-applying hook from the pristine backup.");
+            Info("Re-applying hooks from the pristine backup.");
         }
         else
         {
@@ -171,10 +183,10 @@ internal static class Program
         File.Move(temp, target, overwrite: true);
         Info("Patched BBI.Unity.Game.dll.");
 
-        if (!IsPatched(target, managed))
-            throw new InvalidOperationException("Post-patch verification failed — the hook is not present.");
+        if (!FindHooks(target, managed).All)
+            throw new InvalidOperationException("Post-patch verification failed — the hooks are not present.");
 
-        Info("Verified: the Subsystem hook is present.");
+        Info("Verified: both Subsystem hooks are present.");
         Info("");
         Info("Put your patch.json in the Data folder (one level up from Managed) and start a match.");
         Info("Subsystem.log will appear next to it.");
@@ -186,48 +198,65 @@ internal static class Program
         var hookType = game.MainModule.GetType(HookTypeName)
             ?? throw new InvalidOperationException($"{HookTypeName} not found — is this really BBI.Unity.Game.dll?");
 
-        var hookMethod = hookType.Methods.FirstOrDefault(m => m.Name == HookMethodName && m.Parameters.Count == 0)
+        var entityTypesField = hookType.Fields.FirstOrDefault(f => f.Name == EntityTypesFieldName && f.IsStatic)
+            ?? throw new InvalidOperationException($"static field {EntityTypesFieldName} not found on {HookTypeName}.");
+
+        var resetEntityManager = hookType.Methods.FirstOrDefault(m => m.Name == HookMethodName && m.Parameters.Count == 0)
             ?? throw new InvalidOperationException(
                 $"{HookTypeName}::{HookMethodName}() not found. The game's code changed shape; "
                 + "the hook site needs to be re-identified.");
 
-        if (!hookMethod.HasBody)
+        if (!resetEntityManager.HasBody)
             throw new InvalidOperationException($"{HookMethodName} has no body.");
-
-        var entityTypesField = hookType.Fields.FirstOrDefault(f => f.Name == EntityTypesFieldName && f.IsStatic)
-            ?? throw new InvalidOperationException($"static field {EntityTypesFieldName} not found on {HookTypeName}.");
-
-        var loaderType = subsystem.MainModule.GetType(LoaderTypeName)
-            ?? throw new InvalidOperationException($"{LoaderTypeName} not found in {ModAssembly}.");
-
-        var loaderCtor = loaderType.Methods.FirstOrDefault(m => m.IsConstructor && m.Parameters.Count == 0)
-            ?? throw new InvalidOperationException($"{LoaderTypeName} has no parameterless constructor.");
-
-        var loadAttributes = loaderType.Methods.FirstOrDefault(
-                m => m.Name == LoaderMethodName
-                     && m.Parameters.Count == 1
-                     && m.Parameters[0].ParameterType.FullName == entityTypesField.FieldType.FullName)
-            ?? throw new InvalidOperationException(
-                $"{LoaderTypeName}::{LoaderMethodName}({entityTypesField.FieldType.FullName}) not found.");
-
-        var il = hookMethod.Body.GetILProcessor();
 
         // The original 0.4.0 patch appended the call after ResetEntityManager rebuilds the
         // collection via InitializeEntityManager, so anchor on that call rather than on a
         // raw instruction offset.
+        InjectLoaderCall(game, subsystem, resetEntityManager, AnchorMethodName,
+                         entityTypesField, LoaderTypeName, LoaderMethodName);
+
+        InjectLoaderCall(game, subsystem, FindBuffHookMethod(hookType), BuffAnchorMethodName,
+                         entityTypesField, BuffLoaderTypeName, BuffLoaderMethodName);
+    }
+
+    /// <summary>
+    /// Inserts <c>new Loader().Method(ShipbreakersMain.sEntityTypes)</c> immediately after the
+    /// last call to <paramref name="anchorMethodName"/> in <paramref name="hookMethod"/>.
+    /// </summary>
+    private static void InjectLoaderCall(
+        AssemblyDefinition game, AssemblyDefinition subsystem, MethodDefinition hookMethod,
+        string anchorMethodName, FieldDefinition entityTypesField,
+        string loaderTypeName, string loaderMethodName)
+    {
+        var loaderType = subsystem.MainModule.GetType(loaderTypeName)
+            ?? throw new InvalidOperationException($"{loaderTypeName} not found in {ModAssembly}.");
+
+        var loaderCtor = loaderType.Methods.FirstOrDefault(m => m.IsConstructor && m.Parameters.Count == 0)
+            ?? throw new InvalidOperationException($"{loaderTypeName} has no parameterless constructor.");
+
+        var loaderMethod = loaderType.Methods.FirstOrDefault(
+                m => m.Name == loaderMethodName
+                     && m.Parameters.Count == 1
+                     && m.Parameters[0].ParameterType.FullName == entityTypesField.FieldType.FullName)
+            ?? throw new InvalidOperationException(
+                $"{loaderTypeName}::{loaderMethodName}({entityTypesField.FieldType.FullName}) not found.");
+
         var anchor = hookMethod.Body.Instructions.LastOrDefault(
                 i => (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
                      && i.Operand is MethodReference mr
-                     && mr.Name == AnchorMethodName)
+                     && mr.Name == anchorMethodName)
             ?? throw new InvalidOperationException(
-                $"no call to {AnchorMethodName} inside {HookMethodName} — hook site needs re-identifying.");
+                $"no call to {anchorMethodName} inside {hookMethod.DeclaringType.Name}::{hookMethod.Name} "
+                + "— hook site needs re-identifying.");
+
+        var il = hookMethod.Body.GetILProcessor();
 
         var ctorRef = game.MainModule.ImportReference(loaderCtor);
-        var loadRef = game.MainModule.ImportReference(loadAttributes);
+        var loadRef = game.MainModule.ImportReference(loaderMethod);
 
-        // newobj  Subsystem.AttributeLoader::.ctor()
+        // newobj  Subsystem.<Loader>::.ctor()
         // ldsfld  ShipbreakersMain::sEntityTypes
-        // call    Subsystem.AttributeLoader::LoadAttributes(EntityTypeCollection)
+        // call    Subsystem.<Loader>::<Method>(EntityTypeCollection)
         var call = Instruction.Create(OpCodes.Call, loadRef);
         var load = Instruction.Create(OpCodes.Ldsfld, entityTypesField);
         var make = Instruction.Create(OpCodes.Newobj, ctorRef);
@@ -236,19 +265,49 @@ internal static class Program
         il.InsertAfter(anchor, load);
         il.InsertAfter(anchor, make);
 
-        Info($"Injected hook into {HookTypeName}::{HookMethodName} after the {AnchorMethodName} call.");
+        Info($"Injected hook into {hookMethod.DeclaringType.Name}::{hookMethod.Name} after the {anchorMethodName} call.");
     }
+
+    /// <summary>
+    /// The compiler-generated state machine for ShipbreakersMain.OnSceneLoadComplete, found by
+    /// what it does rather than by its name: the <c>&lt;OnSceneLoadComplete&gt;d__29</c> suffix
+    /// is a compiler counter that moves whenever the class gains or loses an iterator.
+    /// </summary>
+    private static MethodDefinition FindBuffHookMethod(TypeDefinition hookType)
+    {
+        var candidates = hookType.NestedTypes
+            .SelectMany(t => t.Methods)
+            .Where(m => m.Name == "MoveNext" && m.HasBody && CallsMethodNamed(m, BuffAnchorMethodName))
+            .ToList();
+
+        return candidates.Count switch
+        {
+            1 => candidates[0],
+            0 => throw new InvalidOperationException(
+                $"no state machine under {HookTypeName} calls {BuffAnchorMethodName}. The game's code "
+                + "changed shape; the commander-buff hook site needs to be re-identified."),
+            _ => throw new InvalidOperationException(
+                $"{candidates.Count} state machines under {HookTypeName} call {BuffAnchorMethodName} "
+                + $"({string.Join(", ", candidates.Select(c => c.DeclaringType.Name))}); "
+                + "the commander-buff hook site is ambiguous and needs to be re-identified."),
+        };
+    }
+
+    private static bool CallsMethodNamed(MethodDefinition method, string name) =>
+        method.Body.Instructions.Any(i => i.Operand is MethodReference mr && mr.Name == name);
 
     // --------------------------------------------------------------- verify
 
     private static int Verify(string managed, string target)
     {
-        var patched = IsPatched(target, managed);
+        var hooks = FindHooks(target, managed);
+        var patched = hooks.All;
         var mod = File.Exists(Path.Combine(managed, ModAssembly));
         var backup = File.Exists(target + BackupSuffix);
         var stale = CountDanglingReferences(target, managed);
 
-        Info($"{TargetAssembly} hooked : {(patched ? "yes" : "no")}");
+        Info($"attributes hook         : {(hooks.Attributes ? "yes" : "no")}");
+        Info($"commander-buff hook     : {(hooks.CommanderBuffs ? "yes" : "no")}");
         Info($"{ModAssembly} present   : {(mod ? "yes" : "no")}");
         Info($"backup present          : {(backup ? "yes" : "no")}");
         Info($"matches this install    : {(stale == 0 ? "yes" : $"NO — {stale} dangling references")}");
@@ -292,7 +351,18 @@ internal static class Program
         return dangling;
     }
 
-    private static bool IsPatched(string target, string managed)
+    private readonly record struct Hooks(bool Attributes, bool CommanderBuffs)
+    {
+        public bool All => Attributes && CommanderBuffs;
+        public bool Any => Attributes || CommanderBuffs;
+    }
+
+    /// <summary>
+    /// Which Subsystem hooks the assembly already contains. Reported separately so that an
+    /// install patched by an older SubsystemPatcher — which only injected the attributes hook —
+    /// is recognised as incomplete rather than as up to date.
+    /// </summary>
+    private static Hooks FindHooks(string target, string managed)
     {
         using var resolver = new DefaultAssemblyResolver();
         resolver.RemoveSearchDirectory(".");
@@ -301,14 +371,26 @@ internal static class Program
             target, new ReaderParameters { AssemblyResolver = resolver });
 
         var type = asm.MainModule.GetType(HookTypeName);
-        var method = type?.Methods.FirstOrDefault(m => m.Name == HookMethodName && m.Parameters.Count == 0);
-        if (method is not { HasBody: true }) return false;
+        if (type == null) return new Hooks(false, false);
 
-        return method.Body.Instructions.Any(
-            i => i.Operand is MethodReference mr
-                 && mr.Name == LoaderMethodName
-                 && mr.DeclaringType?.FullName == LoaderTypeName);
+        var resetEntityManager = type.Methods.FirstOrDefault(m => m.Name == HookMethodName && m.Parameters.Count == 0);
+
+        var attributes = resetEntityManager is { HasBody: true }
+                         && CallsLoader(resetEntityManager, LoaderTypeName, LoaderMethodName);
+
+        var commanderBuffs = type.NestedTypes
+            .SelectMany(t => t.Methods)
+            .Any(m => m.Name == "MoveNext" && m.HasBody
+                      && CallsLoader(m, BuffLoaderTypeName, BuffLoaderMethodName));
+
+        return new Hooks(attributes, commanderBuffs);
     }
+
+    private static bool CallsLoader(MethodDefinition method, string typeFullName, string methodName) =>
+        method.Body.Instructions.Any(
+            i => i.Operand is MethodReference mr
+                 && mr.Name == methodName
+                 && mr.DeclaringType?.FullName == typeFullName);
 
     // -------------------------------------------------------------- restore
 

--- a/SubsystemPatcher/SubsystemPatcher.csproj
+++ b/SubsystemPatcher/SubsystemPatcher.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>SubsystemPatcher</AssemblyName>
+    <RootNamespace>SubsystemPatcher</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+  </ItemGroup>
+
+</Project>

--- a/build/Subsystem.Sdk.csproj
+++ b/build/Subsystem.Sdk.csproj
@@ -71,6 +71,11 @@
       <HintPath>$(ManagedDir)/BBI.Game.Data.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <!-- CommanderID, SimController and the buff save states, for CommanderBuffLoader. -->
+    <Reference Include="BBI.Game">
+      <HintPath>$(ManagedDir)/BBI.Game.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(ManagedDir)/UnityEngine.dll</HintPath>
       <Private>false</Private>

--- a/build/Subsystem.Sdk.csproj
+++ b/build/Subsystem.Sdk.csproj
@@ -1,0 +1,80 @@
+<!--
+  SDK-style build of the Subsystem mod assembly.
+
+  The original Subsystem/Subsystem.csproj is a legacy (pre-SDK) project with bare
+  <Reference> items and no HintPaths: it only ever built on a machine where Visual Studio
+  happened to resolve BBI.Core / BBI.Game.Data / UnityEngine on its own. This project
+  builds the same sources with nothing but the .NET SDK, on Linux, macOS or Windows, by
+  referencing the assemblies straight out of the game install.
+
+    dotnet build build/Subsystem.Sdk.csproj -c Release
+    dotnet build build/Subsystem.Sdk.csproj -c Release -p:ManagedDir="/path/to/Deserts of Kharak/Data/Managed"
+
+  Output: build/bin/Release/net35/Subsystem.dll
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net35</TargetFramework>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Subsystem</AssemblyName>
+    <RootNamespace>Subsystem</RootNamespace>
+    <!-- Sources live in ../Subsystem and are listed explicitly below. -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <!-- The repo carries its own AssemblyInfo.cs. -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <!-- Where the game's managed assemblies live. Override with -p:ManagedDir=... -->
+  <PropertyGroup>
+    <_Common>steamapps/common/Deserts of Kharak/Data/Managed</_Common>
+
+    <ManagedDir Condition="'$(ManagedDir)' == '' AND Exists('$(HOME)/.var/app/com.valvesoftware.Steam/data/Steam/$(_Common)')"
+                >$(HOME)/.var/app/com.valvesoftware.Steam/data/Steam/$(_Common)</ManagedDir>
+    <ManagedDir Condition="'$(ManagedDir)' == '' AND Exists('$(HOME)/.steam/steam/$(_Common)')"
+                >$(HOME)/.steam/steam/$(_Common)</ManagedDir>
+    <ManagedDir Condition="'$(ManagedDir)' == '' AND Exists('$(HOME)/.local/share/Steam/$(_Common)')"
+                >$(HOME)/.local/share/Steam/$(_Common)</ManagedDir>
+    <ManagedDir Condition="'$(ManagedDir)' == '' AND Exists('$(HOME)/Library/Application Support/Steam/$(_Common)')"
+                >$(HOME)/Library/Application Support/Steam/$(_Common)</ManagedDir>
+    <ManagedDir Condition="'$(ManagedDir)' == '' AND Exists('C:/Program Files (x86)/Steam/$(_Common)')"
+                >C:/Program Files (x86)/Steam/$(_Common)</ManagedDir>
+  </PropertyGroup>
+
+  <Target Name="CheckManagedDir" BeforeTargets="BeforeBuild">
+    <Error Condition="'$(ManagedDir)' == ''"
+           Text="Could not find the game's Data/Managed folder. Pass it explicitly: -p:ManagedDir=&quot;/path/to/Deserts of Kharak/Data/Managed&quot;" />
+    <Error Condition="!Exists('$(ManagedDir)/BBI.Core.dll')"
+           Text="BBI.Core.dll not found in ManagedDir '$(ManagedDir)'." />
+    <Message Importance="high" Text="Building against game assemblies in: $(ManagedDir)" />
+  </Target>
+
+  <ItemGroup>
+    <!-- Reference assemblies for .NET Framework 3.5, so this builds without Windows/VS. -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net35" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../Subsystem/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Private=false: never copy the game's own assemblies into the output. -->
+    <Reference Include="BBI.Core">
+      <HintPath>$(ManagedDir)/BBI.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="BBI.Game.Data">
+      <HintPath>$(ManagedDir)/BBI.Game.Data.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>$(ManagedDir)/UnityEngine.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/docs/building.md
+++ b/docs/building.md
@@ -10,7 +10,7 @@ Nothing else — no Visual Studio, no Mono, no Windows.
 | Project | Target | Builds on CI? |
 | --- | --- | --- |
 | `build/Subsystem.Sdk.csproj` | `net35` — the mod assembly, `Subsystem.dll` | **no** |
-| `SubsystemPatcher/` | `net8.0` — installs the hook into the game | yes |
+| `SubsystemPatcher/` | `net8.0` — installs the hooks into the game | yes |
 | `SubsystemLint/` | `net8.0` — validates `patch.json` | yes |
 
 `Subsystem/Subsystem.csproj` is the original 2018 legacy-format project. It is kept for reference
@@ -18,7 +18,7 @@ and is not used by any of the above; `build/Subsystem.Sdk.csproj` compiles the s
 
 ### Why the mod assembly cannot be built on CI
 
-It references `BBI.Core`, `BBI.Game.Data` and `UnityEngine` directly from the game's
+It references `BBI.Core`, `BBI.Game.Data`, `BBI.Game` and `UnityEngine` directly from the game's
 `Data/Managed/` folder. Those assemblies belong to the game and cannot be redistributed, so there
 is no way to build `Subsystem.dll` on a machine without the game installed.
 
@@ -109,8 +109,8 @@ dotnet run --project SubsystemPatcher -c Release -- --managed /tmp/managed-copy 
 dotnet run --project SubsystemPatcher -c Release -- --managed /tmp/managed-copy --restore
 ```
 
-A correct patcher will: report the hook missing, install it, report it present, refuse to patch
-twice, and restore a file whose checksum matches the original exactly. It should also refuse to
+A correct patcher will: report both hooks missing, install them, report them present, refuse to
+patch twice, and restore a file whose checksum matches the original exactly. It should also refuse to
 run against a `BBI.Unity.Game.dll` that does not match the rest of the install — test that by
 dropping the 0.4.0 release's copy in and confirming it reports dangling references.
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,118 @@
+# Building and releasing
+
+## Requirements
+
+The [.NET SDK](https://dotnet.microsoft.com/download) 8.0 or newer, on Windows, Linux or macOS.
+Nothing else — no Visual Studio, no Mono, no Windows.
+
+## The three projects
+
+| Project | Target | Builds on CI? |
+| --- | --- | --- |
+| `build/Subsystem.Sdk.csproj` | `net35` — the mod assembly, `Subsystem.dll` | **no** |
+| `SubsystemPatcher/` | `net8.0` — installs the hook into the game | yes |
+| `SubsystemLint/` | `net8.0` — validates `patch.json` | yes |
+
+`Subsystem/Subsystem.csproj` is the original 2018 legacy-format project. It is kept for reference
+and is not used by any of the above; `build/Subsystem.Sdk.csproj` compiles the same sources.
+
+### Why the mod assembly cannot be built on CI
+
+It references `BBI.Core`, `BBI.Game.Data` and `UnityEngine` directly from the game's
+`Data/Managed/` folder. Those assemblies belong to the game and cannot be redistributed, so there
+is no way to build `Subsystem.dll` on a machine without the game installed.
+
+CI therefore builds the two tools and verifies the mod project still fails cleanly when pointed
+at a missing game folder, rather than silently producing nothing.
+
+## Building the mod
+
+```sh
+dotnet build build/Subsystem.Sdk.csproj -c Release
+```
+
+Output: `build/bin/Release/net35/Subsystem.dll`.
+
+The project locates a Steam install automatically, including Flatpak Steam and the usual macOS
+and Windows paths. Override it when that fails:
+
+```sh
+dotnet build build/Subsystem.Sdk.csproj -c Release \
+  -p:ManagedDir="/path/to/Deserts of Kharak/Data/Managed"
+```
+
+If the folder cannot be found the build fails with a clear message rather than a wall of
+unresolved-type errors.
+
+`net35` is built using the `Microsoft.NETFramework.ReferenceAssemblies.net35` package, which is
+what lets a modern SDK target it on any OS. The game runs Unity 5.2's Mono, so the assembly must
+stay on the .NET 2.0/3.5 profile — do not raise `TargetFramework`.
+
+## Building the tools
+
+```sh
+dotnet build SubsystemPatcher/SubsystemPatcher.csproj -c Release
+dotnet build SubsystemLint/SubsystemLint.csproj -c Release
+```
+
+Both target `net8.0` with `RollForward: LatestMajor`, so they run on any newer runtime too.
+
+`SubsystemLint` compiles `GameLocator.cs` from `SubsystemPatcher` as a linked file so install
+detection lives in one place.
+
+## Installing what you built
+
+```sh
+cp build/bin/Release/net35/Subsystem.dll "<...>/Deserts of Kharak/Data/Managed/"
+dotnet run --project SubsystemPatcher -c Release
+```
+
+The patcher backs up the original `BBI.Unity.Game.dll` before writing, and `--restore` puts it
+back byte-for-byte.
+
+## Releasing
+
+`.github/workflows/release.yml` runs on any tag matching `v*`:
+
+```sh
+git tag v0.5.0
+git push origin v0.5.0
+```
+
+It publishes both tools as portable framework-dependent builds — one set of files that runs on
+every OS, about 600 KB each rather than the ~67 MB a self-contained build produces per platform —
+packages them with the docs, sources and `patch.example.json`, and creates a GitHub release with
+that archive attached.
+
+It can also be run from the Actions tab via `workflow_dispatch` to produce the archive as a
+build artifact without tagging or publishing anything.
+
+Note that a release **cannot** contain `Subsystem.dll` for the reason above. The archive ships
+the sources and the build project; users run one `dotnet build` against their own installation.
+This is also what keeps the mod working across game updates, since it is compiled against the
+assemblies actually installed.
+
+## CI
+
+`.github/workflows/ci.yml` runs on pushes to `master` and `develop`, on pull requests, and on
+demand. It builds both tools and checks the mod project's `ManagedDir` guard still fires.
+
+## Testing a change to the patcher
+
+There is no automated test suite. The checks worth repeating by hand, against a copy of
+`Data/Managed` rather than the real install:
+
+```sh
+dotnet run --project SubsystemPatcher -c Release -- --managed /tmp/managed-copy --verify
+dotnet run --project SubsystemPatcher -c Release -- --managed /tmp/managed-copy
+dotnet run --project SubsystemPatcher -c Release -- --managed /tmp/managed-copy --verify
+dotnet run --project SubsystemPatcher -c Release -- --managed /tmp/managed-copy --restore
+```
+
+A correct patcher will: report the hook missing, install it, report it present, refuse to patch
+twice, and restore a file whose checksum matches the original exactly. It should also refuse to
+run against a `BBI.Unity.Game.dll` that does not match the rest of the install — test that by
+dropping the 0.4.0 release's copy in and confirming it reports dangling references.
+
+[compatibility.md](compatibility.md) records the deeper verification that was done on the IL
+rewrite, and how to repeat it if the patcher's approach ever changes.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,99 @@
+# Why 0.4.0 stopped working, and how the fix works
+
+Subsystem 0.4.0 was released in November 2018 and works against the game as it shipped then.
+On a current build of _Homeworld: Deserts of Kharak_ it makes the main menu misbehave and the
+transition into a match fail. This document records what actually broke, so that the next person
+who has to re-fix this does not have to rediscover it.
+
+## The short version
+
+`Subsystem.dll` was never the problem. The install instructions were.
+
+0.4.0 shipped a **complete, pre-patched `BBI.Unity.Game.dll`** — the entire game assembly as it
+existed in 2018 — and told you to overwrite the game's own copy. Doing that on a current install
+replaces years of game code with the 2018 version.
+
+The actual modification inside that 1.85 MB file is three IL instructions.
+
+## The hook
+
+At the end of `BBI.Unity.Game.ShipbreakersMain.ResetEntityManager()`, immediately after the call
+to `InitializeEntityManager`:
+
+```
+newobj  instance void Subsystem.AttributeLoader::.ctor()
+ldsfld  class BBI.Core.Data.EntityTypeCollection BBI.Unity.Game.ShipbreakersMain::sEntityTypes
+call    instance void Subsystem.AttributeLoader::LoadAttributes(class BBI.Core.Data.EntityTypeCollection)
+```
+
+That is the whole modification. `ResetEntityManager` runs at the start of every match, which is
+why the README says stats are reloaded at the beginning of every game.
+
+`SubsystemPatcher` applies exactly these three instructions to whatever `BBI.Unity.Game.dll` you
+have, instead of replacing the file. Because it patches your copy, it keeps working across game
+updates — you just re-run it after each one.
+
+## Why the 2018 assembly breaks a current install
+
+The 2018 `BBI.Unity.Game.dll` references **19 types and 51 members** that no longer exist in the
+current game assemblies. They are concentrated in the multiplayer, lobby, leaderboard, stats and
+DLC layers, which were rewritten when the game moved to Epic Online Services:
+
+| Assembly | Examples of references that no longer resolve |
+| --- | --- |
+| `BBI.Steam` | `SteamLeaderboard`, `SteamLeaderboardUploader`, `SteamLobbyFinder`, `PlayerLobbyListInfo`, `AutomatchState`, `LobbyRole`, `SteamDLCPack` |
+| `BBI.Spark` | `SparkSteamBridge`, `SparkProviderSettings..ctor` |
+| `BBI.Unity.Game.Data` | `Network.SteamStatDefinition` |
+| `BBI.Core` | `IPlayerGroupMetaData.MigrateGroup` |
+
+A missing member does not fail at load time — it fails when the JIT first compiles the method
+that uses it, throwing `MissingMethodException` or `TypeLoadException`. Menu and match-start code
+touches lobby, stats and DLC paths, which is exactly where the reported symptoms appear.
+
+`SubsystemPatcher --verify` reports this as a dangling-reference count, and the patcher refuses
+to run against a mismatched assembly rather than making things worse.
+
+## Why the mod assembly itself still works
+
+Checked against a current install, `Subsystem.dll` from the 0.4.0 release:
+
+- resolves **every** type and member reference it uses — zero unresolved
+- has **all 21** of its wrapper classes still satisfying the game interfaces they implement, with
+  no unimplemented members and no orphaned overrides
+- has **every** wrapper copy-constructor copying 100% of its interface's properties, so no field
+  silently defaults to zero
+
+The 2018 sources also still compile against current game assemblies with no errors and no
+warnings, producing an assembly that differs from the released binary only by one compiler
+codegen idiom in one method.
+
+In other words: seven years of game updates did not change the data model Subsystem patches.
+
+## Verifying that the patch is safe
+
+The patcher rewrites `BBI.Unity.Game.dll` with Mono.Cecil, which reconstructs the whole file
+rather than splicing bytes. That was checked rather than assumed:
+
+- **Every method body is unchanged except one.** Comparing an opcode-and-operand fingerprint of
+  all 15,907 members before and after, only `ResetEntityManager` differs: +3 instructions, with
+  its 2 exception handlers and 9 locals intact.
+- **No metadata is lost.** All 26,312 lines of custom attributes and metadata flags — 109
+  `[Serializable]` types, 10 `[NonSerialized]` fields, class layout, security declarations — are
+  byte-identical before and after.
+- **Nothing else to lose.** The assembly has no embedded resources, no exported types, no module
+  references and no P/Invoke; `ILOnly` and the 32-bit architecture flag are preserved.
+- **Restore is byte-exact.** `--restore` reproduces the original file's checksum exactly.
+
+The output file is smaller than the original. That is metadata padding, not lost content.
+
+## Working on this in future
+
+Two tools in this repository exist to make the next investigation cheaper:
+
+- `SubsystemLint` validates a `patch.json` against the shapes Subsystem deserializes and the
+  names your install actually loaded. See [finding-names-and-values.md](finding-names-and-values.md).
+- `EntityTypeDumper` (inside the mod) writes `Data/Subsystem.entities.log` on every game start,
+  listing every entity type, its components, and each weapon's targeting data.
+
+If a future game update does move the hook site, `SubsystemPatcher` fails loudly with the type
+and method it could not find, rather than producing a broken assembly.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,7 +15,7 @@ replaces years of game code with the 2018 version.
 
 The actual modification inside that 1.85 MB file is three IL instructions.
 
-## The hook
+## The hooks
 
 At the end of `BBI.Unity.Game.ShipbreakersMain.ResetEntityManager()`, immediately after the call
 to `InitializeEntityManager`:
@@ -26,8 +26,26 @@ ldsfld  class BBI.Core.Data.EntityTypeCollection BBI.Unity.Game.ShipbreakersMain
 call    instance void Subsystem.AttributeLoader::LoadAttributes(class BBI.Core.Data.EntityTypeCollection)
 ```
 
-That is the whole modification. `ResetEntityManager` runs at the start of every match, which is
-why the README says stats are reloaded at the beginning of every game.
+`ResetEntityManager` runs at the start of every match, which is why the README says stats are
+reloaded at the beginning of every game. That was the whole of the 0.4.0 modification.
+
+A second hook, of the same shape, applies the per-commander section of `patch.json`. It goes in
+the `OnSceneLoadComplete` coroutine, immediately after the call to `SimController.PostLoadInit`:
+
+```
+newobj  instance void Subsystem.CommanderBuffLoader::.ctor()
+ldsfld  class BBI.Core.Data.EntityTypeCollection BBI.Unity.Game.ShipbreakersMain::sEntityTypes
+call    instance void Subsystem.CommanderBuffLoader::ApplyCommanderBuffs(class BBI.Core.Data.EntityTypeCollection)
+```
+
+It has to be this late. Per-commander entity types do not exist until `Sim`'s constructor calls
+`MakeAllTypesBuffableForCommander`, and on a save load `Sim.OnLoad` throws them away and rebuilds
+them; `PostLoadInit` is after both. The hook site is found by looking for the state machine under
+`ShipbreakersMain` that calls `PostLoadInit`, rather than by its `<OnSceneLoadComplete>d__29`
+name — that suffix is a compiler counter and moves whenever the class gains or loses an iterator.
+
+`SubsystemPatcher --verify` reports the two hooks separately, so an install patched by an older
+version is recognised as incomplete rather than as up to date.
 
 `SubsystemPatcher` applies exactly these three instructions to whatever `BBI.Unity.Game.dll` you
 have, instead of replacing the file. Because it patches your copy, it keeps working across game
@@ -74,9 +92,18 @@ In other words: seven years of game updates did not change the data model Subsys
 The patcher rewrites `BBI.Unity.Game.dll` with Mono.Cecil, which reconstructs the whole file
 rather than splicing bytes. That was checked rather than assumed:
 
-- **Every method body is unchanged except one.** Comparing an opcode-and-operand fingerprint of
-  all 15,907 members before and after, only `ResetEntityManager` differs: +3 instructions, with
-  its 2 exception handlers and 9 locals intact.
+- **Every method body is unchanged except the two hook sites.** Comparing an opcode-and-operand
+  fingerprint of all 8,722 method bodies before and after, only these differ, and no member is
+  added or removed:
+
+  | Method | Instructions | Locals | Handlers |
+  | --- | --- | --- | --- |
+  | `ShipbreakersMain::ResetEntityManager` | 88 → 91 | 9 → 9 | 2 → 2 |
+  | `ShipbreakersMain/<OnSceneLoadComplete>d__29::MoveNext` | 769 → 772 | 15 → 15 | 2 → 2 |
+
+  Three instructions each, exception handlers and locals intact. (The single-hook figure this
+  document used to quote — 15,907 members, one changed method — was from before the
+  commander-buff hook existed.)
 - **No metadata is lost.** All 26,312 lines of custom attributes and metadata flags — 109
   `[Serializable]` types, 10 `[NonSerialized]` fields, class layout, security declarations — are
   byte-identical before and after.

--- a/docs/finding-names-and-values.md
+++ b/docs/finding-names-and-values.md
@@ -1,0 +1,172 @@
+# Finding entity names, component names and values
+
+Every key in `patch.json` is a name from the game's data. This document explains how to discover
+those names and their current values for **your** installed version, rather than trusting a list
+someone published years ago.
+
+## The three files that tell you everything
+
+All three live in `Deserts of Kharak/Data/`.
+
+| File | Written when | Tells you |
+| --- | --- | --- |
+| `Subsystem.entities.log` | every game start | every entity type, its components, and each weapon's targeting data |
+| `Subsystem.log` | every game start, if the patch parsed | what your patch changed, and the **previous value** of each field |
+| `output_log.txt` | continuously, by the game | whether Subsystem loaded and whether the patch threw |
+
+## Subsystem.entities.log — the name reference
+
+Written on every game start, before the patch is read, so it is produced even when `patch.json`
+is missing or broken.
+
+```
+C_HAC_Upgrade01_MP
+    AbilityAttributesData: Ability_C_Grenade_MP
+    DetectableAttributesData
+    UnitAttributesData: C_HAC_Upgrade01_UnitAttributesAsset_MP
+    UnitMovementAttributesData
+    WeaponAttributesData: C_HAC_Upgrade01_Weapon_G2A_MP
+        auto-acquire: yes   auto-fire: yes   damage: 250   cooldown: 700ms
+        DamageType: Missile   TargetStyle: TurretImpactRun
+        ranges: Short=1400 Medium=1400 Long=1400
+        vs Air (Or): CanTarget 1
+```
+
+How to read it:
+
+- **Column 0** is an entity type name — a key under `Entities` in `patch.json`.
+- **Four-space indent** is a component. `Type: Name` means the component is addressed *by that
+  name* (weapons, abilities, storages). A bare `Type` means it is addressed by type alone.
+- **Eight-space indent** is per-weapon detail, described below.
+
+Note that the component name is not always the entity name: above, the entity is
+`C_HAC_Upgrade01_MP` but its weapon is `C_HAC_Upgrade01_Weapon_G2A_MP`.
+
+### The weapon detail lines
+
+- `auto-acquire` / `auto-fire` — whether the unit uses this weapon on its own. A weapon with
+  `auto-fire: no` only fires when you trigger its ability. That is how grenade and smoke
+  launchers work, and it is why a unit can look like it "refuses to shoot".
+- `ranges` — the distance bands. This is the weapon's actual reach.
+- `vs <class> (<op>): <modifier> <amount>` — one line per entry in `Modifiers`, **in index
+  order**. This is where ground-versus-air gating lives: `CanTarget` / `CanNotTarget` against a
+  `UnitClass`. The index order matters when patching (see
+  [patch-reference.md](patch-reference.md#lists-are-keyed-by-index-not-by-name)).
+
+## Subsystem.log — current values, for free
+
+You do not need to look up a field's current value anywhere. Patch it to anything and the log
+tells you what it was:
+
+```
+EntityType: C_HAC_Upgrade01_MP
+
+  UnitAttributes:
+
+    MaxHealth: 6000 (was: 1800)
+    Armour: 20 (was: 5)
+
+  WeaponAttributes: C_HAC_Upgrade01_Weapon_G2A_MP
+
+    BaseDamagePerRound: 900 (was: 250)
+```
+
+This is the fastest way to learn the game's native scale for a field before deciding on a value.
+
+It also reports what it could **not** find:
+
+| Line | Meaning |
+| --- | --- |
+| `NOTICE: EntityType not found` | the `Entities` key does not exist in this install |
+| `ERROR: <Type> not found` | the entity exists but has no such component, or no component by that name |
+| `(created)` | the element did not exist and was added |
+| `(removed)` | the element was removed |
+
+If `Subsystem.log` does not appear at all, the patch never ran — see
+[troubleshooting.md](troubleshooting.md).
+
+## SubsystemLint — check before you launch
+
+```sh
+dotnet run --project SubsystemLint -c Release
+```
+
+With no arguments it checks `Data/patch.json` of the detected install, using
+`Data/Subsystem.entities.log` for name checking when it exists. It validates:
+
+- property names against the patch classes, with a spelling suggestion
+- value types (a string where a number belongs, a decimal in an integer field)
+- enum values, including `[Flags]` combinations like `"Hover, Carrier"`
+- list keys that must be integers
+- entity and component names against your install, with a spelling suggestion
+
+Exit codes: `0` clean, `2` problems found, `1` could not run.
+
+This matters more than it looks. An unknown property does not just get ignored — it makes the
+whole patch throw and apply nothing. See
+[patch-reference.md](patch-reference.md#an-unknown-key-discards-the-entire-patch).
+
+## Identifying which entity is which unit
+
+Entity names are internal codenames and do not always match the in-game name. `C_HAC` is the
+Armored Assault Vehicle; `C_HAC_Upgrade01` is the Missile Battery.
+
+Three ways to map a unit to its entity, in increasing order of effort:
+
+1. **Patch a stat and look at the unit card.** Set `MaxHealth` to something unmistakable, start a
+   match, build the unit. `Subsystem.log` confirms which entity you actually hit.
+2. **Read the component names.** They are usually descriptive: a unit with
+   `WeaponAttributesData: ..._Weapon_G2A_...` is anti-air, `..._G2G_...` is ground,
+   `..._G2GA_...` is both.
+3. **Search the localization strings.** The game's UI text is in `Data/sharedassets0.assets` as
+   CSV rows. Searching it for a unit's in-game name often reveals the codename — the tutorial
+   objective "Produce Three Armored Assault Units (`{hacsProduced}`/3)" is what confirms that
+   "Armored Assault" means `HAC`.
+
+   ```sh
+   grep -aoE "[ -~]{0,60}Armored Assault[ -~]{0,60}" \
+     "<...>/Deserts of Kharak/Data/sharedassets0.assets" | sort -u
+   ```
+
+## Campaign and multiplayer are different entities
+
+Most units exist twice, and **they do not share stats**:
+
+| Campaign | Multiplayer / skirmish |
+| --- | --- |
+| `C_HAC` | `C_HAC_MP` |
+| `C_HAC_Upgrade01` | `C_HAC_Upgrade01_MP` |
+
+Their components are suffixed to match, and not always with the same suffix:
+
+| Campaign component | Multiplayer component |
+| --- | --- |
+| `C_HAC_Upgrade01_Weapon_G2A_Campaign` | `C_HAC_Upgrade01_Weapon_G2A_MP` |
+| `C_HAC_Upgrade01_Weapon_Ballistic_Grenade` | `C_HAC_Upgrade01_Weapon_Ballistic_Grenade_MP` |
+
+Note the campaign G2A weapon is `_Campaign`, not unsuffixed. Do not assume the pattern — read the
+dump.
+
+The two variants can also differ in **content**, not just numbers. The multiplayer AAV
+(`C_HAC_MP`) carries a `C_HAC_Weapon_G2GA_MP` that engages ground and air; the campaign AAV
+(`C_HAC`) has no such weapon and cannot shoot air at all.
+
+Patching both variants in one file is harmless — an entity you are not currently playing with is
+simply patched and never used. `SubsystemLint` will catch it if you put multiplayer component
+names under a campaign entity.
+
+## Reading the game's own assemblies
+
+For questions the logs cannot answer — what an enum's legal values are, how a field is consumed
+by the simulation — decompile the assemblies in `Data/Managed/`. Any IL tool works;
+[Mono.Cecil](https://www.nuget.org/packages/Mono.Cecil) is enough to enumerate types and dump
+method bodies, and is already a dependency of the tooling here.
+
+The assemblies worth knowing:
+
+| Assembly | Contains |
+| --- | --- |
+| `BBI.Game.Data.dll` | the attribute interfaces and enums that `patch.json` maps onto |
+| `BBI.Core.dll` | `EntityTypeCollection`, `EntityTypeAttributes`, `Fixed64`, and the bundled LitJson |
+| `BBI.Game.dll` | the simulation — how weapons fire, how ranges and modifiers are consumed |
+| `BBI.Unity.Game.dll` | presentation, the HUD, and the hook site |

--- a/docs/finding-names-and-values.md
+++ b/docs/finding-names-and-values.md
@@ -26,6 +26,7 @@ C_HAC_Upgrade01_MP
     UnitAttributesData: C_HAC_Upgrade01_UnitAttributesAsset_MP
     UnitMovementAttributesData
     WeaponAttributesData: C_HAC_Upgrade01_Weapon_G2A_MP
+        weapon ID (for commander buffs): <the loadout's ID for this weapon>
         auto-acquire: yes   auto-fire: yes   damage: 250   cooldown: 700ms
         DamageType: Missile   TargetStyle: TurretImpactRun
         ranges: Short=1400 Medium=1400 Long=1400
@@ -44,6 +45,11 @@ Note that the component name is not always the entity name: above, the entity is
 
 ### The weapon detail lines
 
+- `weapon ID (for commander buffs)` — the ID this weapon has in the unit's loadout. It is *not*
+  necessarily the component name on the line above. The `Entities` section keys weapons by the
+  component name; buffs under `Commanders` key on this ID instead, and a wrong one is matched
+  silently against nothing. The line is only printed for weapons that are actually bound to a
+  unit's loadout.
 - `auto-acquire` / `auto-fire` — whether the unit uses this weapon on its own. A weapon with
   `auto-fire: no` only fires when you trigger its ability. That is how grenade and smoke
   launchers work, and it is why a unit can look like it "refuses to shoot".

--- a/docs/patch-reference.md
+++ b/docs/patch-reference.md
@@ -33,18 +33,23 @@ and is reported in `Subsystem.log`.
 
 ### Lists are keyed by index, not by name
 
-Four properties are lists, and their keys must be consecutive integers as strings:
+Five properties are lists, and their keys must be consecutive integers as strings:
 
 - `ExperienceAttributesPatch.Levels`
 - `ExperienceLevelAttributesPatch.Buff`
 - `WeaponAttributesPatch.Modifiers`
 - `WeaponAttributesPatch.EntityTypesToSpawnOnImpact`
+- `EntityTypeBuffPatch.Buffs`
 
 ```json
 "Modifiers": {
   "0": { "TargetClass": "Air", "ClassOperator": "Or", "Modifier": "CanTarget", "Amount": 1 }
 }
 ```
+
+Entries are processed in **numeric** index order. (Before this was fixed they were processed in
+string order, which puts `"10"` between `"1"` and `"2"` — so any list longer than ten entries
+tripped the non-consecutive check at `"10"` and silently discarded everything from there on.)
 
 Rules enforced by `applyListPatch`:
 
@@ -111,7 +116,188 @@ Entities
     ├── AbilityAttributes  ── <name> ── AbilityAttributesPatch
     ├── StorageAttributes  ── <name> ── StorageAttributesPatch
     └── WeaponAttributes   ── <name> ── WeaponAttributesPatch
+
+Commanders
+└── <commander ID>                      CommanderPatch
+    └── EntityTypeBuffs
+        └── <entity name or prefix>     EntityTypeBuffPatch
+            ├── UseAsPrefix             bool
+            ├── UnitClass               UnitClass
+            ├── ClassOperator           FlagOperator
+            └── Buffs ── <index> ────── AttributeBuffPatch
 ```
+
+## Commanders — changing stats for one player only
+
+Everything under `Entities` patches the shared entity type templates, so it applies to *every*
+player who fields that unit. `Commanders` is the other option: it gives one commander's units
+different numbers and leaves everyone else's alone.
+
+```json
+{
+  "Commanders": {
+    "1": {
+      "EntityTypeBuffs": {
+        "C_Escort_MP": {
+          "Buffs": {
+            "0": { "Attribute": "Unit_MaxHealth", "Mode": "Set", "Value": 5000 },
+            "1": { "Attribute": "UnitDynamics_MaxSpeed", "Mode": "AddPercent", "Value": 25 }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This is the same mechanism a research upgrade uses. The engine keeps a per-commander copy of each
+entity type and applies *attribute buffs* to it; units resolve their attributes through that copy
+when they spawn. Subsystem applies your buffs from a second hook, once the simulation exists.
+
+### Which commander am I?
+
+Commander IDs are numbers, and `Subsystem.log` prints the ones you need at the top of its
+`Commander buffs` section every match:
+
+```
+Commander buffs
+
+  local commander: 1, CPU commander: 2
+```
+
+Key on the number, not on "me". A patch that said "whoever is playing" would apply to a different
+commander on every machine and desync a multiplayer game immediately.
+
+### Matching more than one entity type
+
+| Property | Effect |
+| --- | --- |
+| `UseAsPrefix` | Match every entity type whose name *starts with* the key, instead of the one named by it |
+| `UnitClass` | Only types whose `UnitAttributes.Class` matches. Omitted means no class filter |
+| `ClassOperator` | `Or` (shares any flag, the default) or `And` (has all of them) |
+
+```json
+"C_": { "UseAsPrefix": true, "UnitClass": "Air", "Buffs": { "0": { "Attribute": "Unit_Armour", "Mode": "Add", "Value": 2 } } }
+```
+
+Only entity types that have `UnitAttributes` can be buffed; the engine skips everything else, and
+`Subsystem.log` says so when nothing matched.
+
+### Buffs
+
+`Buffs` is an **indexed list** — keys `"0"`, `"1"`, … — of the same shape used by
+`ExperienceAttributes.Levels[].Buff`:
+
+| Property | Type | Meaning |
+| --- | --- | --- |
+| `Attribute` | `Buff.CategoryAndID` | Which attribute, e.g. `Unit_MaxHealth` |
+| `Mode` | `AttributeBuffMode` | `Add`, `AddPercent`, `Set`, `SetAndHold` |
+| `Value` | `int` | Whole number. `AddPercent` takes `25` for +25% |
+| `Name` | `string` | Which component, for the categories that have several. Omit to hit them all |
+
+`Value` is always an `int`, including for attributes that are `double` under `Entities`. To halve
+a multiplier, use `AddPercent` with `-50` rather than a fractional `Set`.
+
+### The attributes you can buff
+
+This is the whole list — it is fixed by the engine, and it is much smaller than what `Entities`
+can reach. Anything not here (enum values, strings, projectile types, weapon `Modifiers`, turret
+settings) can only be changed globally, under `Entities`.
+
+| Category | `Attribute` values |
+| --- | --- |
+| Unit | `Unit_MaxHealth`, `Unit_Armour`, `Unit_Resource1Cost`, `Unit_Resource2Cost`, `Unit_PopCapCost`, `Unit_ProductionTime`, `Unit_SensorRadius`, `Unit_ContactRadius`, `Unit_NumProductionQueues`, `Unit_AggroRange`, `Unit_LeashRange`, `Unit_AlertRange`, `Unit_FireRateDisplay`, `Unit_NonAutoTargetable`, `Unit_DamageReceivedMultiplier`, `Unit_AccuracyReceivedMultiplier` |
+| UnitDynamics | `UnitDynamics_MaxSpeed`, `UnitDynamics_AccelerationTime`, `UnitDynamics_BrakingTime`, `UnitDynamics_MinCruiseSpeed`, `UnitDynamics_MaxSpeedTurnRadius` |
+| UnitWeapon | `UnitWeapon_BaseDamagePerRound`, `UnitWeapon_RateOfFire`, `UnitWeapon_CooldownTime`, `UnitWeapon_ReloadTime`, `UnitWeapon_AreaOfEffect`, `UnitWeapon_ExcludeFromAutoTargetAcquisition`, `UnitWeapon_ExcludeFromAutoFire`, `UnitWeapon_ActiveStatusEffectsIndex` |
+| WeaponRange | `WeaponRange_DistanceShort`, `WeaponRange_DistanceMedium`, `WeaponRange_DistanceLong`, `WeaponRange_AccuracyShort`, `WeaponRange_AccuracyMedium`, `WeaponRange_AccuracyLong` |
+| Ability | `Ability_CooldownTimeSecs`, `Ability_WarmupTimeSecs`, `Ability_CostR1`, `Ability_CostR2` |
+| Inventory | `Inventory_Capacity`, `Inventory_StartingAmount` |
+| Harvester | `Harvester_SalvageDistance`, `Harvester_CycleTime`, `Harvester_ResourcesLoadedPerCycle`, `Harvester_ResourcesExtractedPerCycle` |
+| HangarBay | `HangarBay_MinDockCoolingSeconds`, `HangarBay_MaxDamageCoolingSeconds`, `HangarBay_MaxPayloadCoolingSeconds` |
+| PowerShunt | `PowerShunt_PowerLevelChargeTimeSeconds`, `PowerShunt_HeatThreshold` |
+| PowerSystem | `PowerSystem_StartingPowerLevelIndex`, `PowerSystem_StartingMaxPowerLevelIndex` |
+| UnitCombatBehaviour | `UnitCombatBehaviour_MinDesiredCombatRange`, `UnitCombatBehaviour_MaxDesiredCombatRange` |
+
+`Buff.CategoryAndID` also defines `Commander_PopulationCap`, `Commander_DockedReloadModifier`,
+`Commander_DockedRepairModifier` and `Commander_IgnoreMinimumDockTime`. Those attach to the
+commander rather than to a unit type, through engine API that is internal to `BBI.Game` and not
+reachable from the mod assembly. Subsystem **rejects them with an error in `Subsystem.log`**
+rather than accepting them and quietly doing nothing.
+
+### What `Name` means, per category
+
+Only some categories have more than one component to choose between. An omitted or empty `Name`
+always means "every component in this category".
+
+| Category | `Name` is |
+| --- | --- |
+| `UnitWeapon_*`, `WeaponRange_*` | the **weapon ID from the unit's loadout** — see below |
+| `Ability_*` | the ability name, as printed in `Subsystem.entities.log` |
+| `Inventory_*` | the inventory ID, the same key `StorageAttributes.InventoryLoadout` uses |
+| `HangarBay_*` | the hangar bay name |
+| everything else | ignored — the unit has only one of these |
+
+**Weapons are the trap.** The `Entities` section keys weapons by the weapon component's name
+(`C_Escort_Weapon_G2G_MP`); weapon *buffs* key on `WeaponBinding.WeaponID`, which is a different
+string. Getting it wrong is silent: the buff is simply never matched. `Subsystem.entities.log`
+prints the right one under each weapon:
+
+```
+    WeaponAttributesData: C_Escort_Weapon_G2G_MP
+        weapon ID (for commander buffs): <-- use this one
+```
+
+If the unit has only one weapon, leave `Name` out and the question does not arise.
+
+### Loading a save
+
+Buffs are saved with the game and restored when you load, which is the main reason to use this
+rather than patching the per-commander copies directly — those are rebuilt from scratch on load
+and any direct edit to them would be lost.
+
+Because loading a save re-runs Subsystem's hook on top of buffs the game has already restored,
+a buff that is already present — same attribute, mode and value — is not applied a second time.
+Without that, `Add` and `AddPercent` would compound every time you loaded. One side effect: two
+identical entries in the same `Buffs` list collapse into one. Write `Add 200` rather than `Add
+100` twice.
+
+### Multiplayer
+
+The usual rule still holds — every player needs byte-identical `patch.json` — and it is enough,
+because every client applies the same buffs to the same commander IDs. What you must not do is
+key on the local player; that is why there is no "me" and no name-based lookup here.
+
+Giving one commander better units is, of course, an unfair game. This is aimed at single-player
+and at skirmishes against the AI.
+
+### Proving it is really per-commander
+
+Buffing your own faction is not a test. In the campaign you are Coalition (`C_`) and the enemy is
+Gaalsien (`G_`), so a `C_*` buff looks player-only whether or not the scoping works — and campaign
+entity names carry no `_MP` suffix, so `C_HAC`, not `C_HAC_MP`.
+
+**The control that costs nothing: change the commander key to an ID that is not in the match.**
+Take a buff you have watched apply, re-key it from `"1"` to `"7"`, and start the mission again.
+The buff must now do nothing — if it still applies, it was never commander-scoped. Two runs, no
+risk to the game either way, and it distinguishes real scoping from a global patch outright.
+
+The louder control is to buff the *enemy's* units under **your** commander ID:
+
+```json
+"G_": { "UseAsPrefix": true, "Buffs": { "0": { "Attribute": "Unit_MaxHealth", "Mode": "Set", "Value": 99999 } } }
+```
+
+You never own Gaalsien units, so if the scoping holds this does nothing at all. Be aware of what
+you are betting: the failure mode is a mission full of unkillable enemies. Use a *nerf* rather
+than a buff — `Set 100` instead of `Set 99999` — if you would rather a leak made the mission easy
+than unplayable.
+
+(One exception, if you go looking for it: capturing an enemy unit re-resolves its attributes for
+its new owner — `UnitManager.TransferUnitToCommander` goes through
+`GetCommanderSpecificEntityType` — so a captured unit does pick up its captor's buffs.)
+
+In a skirmish you have the easier option of a mirror matchup: same faction on both sides, buff the
+unit for one commander ID and watch the other side's identical units behave normally.
 
 ## UnitAttributes
 

--- a/docs/patch-reference.md
+++ b/docs/patch-reference.md
@@ -1,0 +1,258 @@
+# patch.json reference
+
+The complete set of things Subsystem can change, and the rules that govern the file.
+
+Read [finding-names-and-values.md](finding-names-and-values.md) first if you do not yet know
+which entity and component names to use.
+
+## Rules that will bite you
+
+### An unknown key discards the entire patch
+
+Subsystem deserializes with the LitJson bundled in `BBI.Core.dll`. Its
+`JsonReader.ignore_extra_keys` field is never assigned, so it defaults to `false`, and
+`JsonMapper.ReadValue` throws on the first property it does not recognise:
+
+```
+The type {0} doesn't have the property '{1}'
+```
+
+`AttributeLoader` catches that and writes a single line to the game's `output_log.txt`:
+
+```
+[SUBSYSTEM] Error applying patch file: ...
+```
+
+**No `Subsystem.log` is written and nothing at all is patched** — not just the misspelled entry,
+the whole file. One typo anywhere silently disables everything.
+
+This is what `SubsystemLint` is for. Run it before you launch.
+
+Names behave differently: an entity or component name that does not exist skips only that entry
+and is reported in `Subsystem.log`.
+
+### Lists are keyed by index, not by name
+
+Four properties are lists, and their keys must be consecutive integers as strings:
+
+- `ExperienceAttributesPatch.Levels`
+- `ExperienceLevelAttributesPatch.Buff`
+- `WeaponAttributesPatch.Modifiers`
+- `WeaponAttributesPatch.EntityTypesToSpawnOnImpact`
+
+```json
+"Modifiers": {
+  "0": { "TargetClass": "Air", "ClassOperator": "Or", "Modifier": "CanTarget", "Amount": 1 }
+}
+```
+
+Rules enforced by `applyListPatch`:
+
+- an index **below** the current count **overwrites** that entry
+- an index **equal to** the current count **appends**
+- an index **above** the current count is an error, and processing of that list stops
+- a non-integer key is an error, and processing of that list stops
+- `"Remove": true` deletes the entry
+
+So to add a modifier without destroying an existing one, you must know how many there already
+are. `Subsystem.entities.log` prints them in index order.
+
+Every other dictionary is keyed by name: `Entities`, `AbilityAttributes`, `StorageAttributes`,
+`WeaponAttributes`, `HangarBays`, and `InventoryLoadout` (keyed by inventory ID).
+
+### Some changes only apply to newly spawned units
+
+Unit-level values — health, armour, speed, pop cost, sensor radius — are copied into a unit's
+simulation state when it spawns. Patching them does not retroactively change units that already
+exist in a saved game or on the field.
+
+Weapon behaviour resolves through the weapon binding on every shot, so weapon changes take effect
+on existing units immediately.
+
+**Build a new unit, or start a new match, before concluding a change did not work.**
+
+### The unit card includes buffs
+
+The HUD stat card shows the unit's live simulation state, which includes veterancy and upgrade
+buffs. A unit with a base `MaxSpeed` of 50 can display `SPEED 65`. A freshly built unit shows the
+base value; a promoted one shows more. `Subsystem.log` always reports the underlying attribute.
+
+### Multiplayer
+
+Every player must have the same Subsystem version **and** byte-identical `patch.json`, or the
+game will desync.
+
+## Value syntax
+
+| Type in the tables below | JSON |
+| --- | --- |
+| `int?` | number, whole — `2`, not `2.5` |
+| `double?`, `float?` | number — `0.4`, `18.0` |
+| `bool?` | `true` / `false` |
+| `string` | string |
+| `string[]` | array of strings |
+| enum | string naming the member — `"Linear"` |
+| `[Flags]` enum | one string, comma-separated — `"Hover, Carrier"` |
+
+Values the game stores as `Fixed64` are written as JSON numbers. The conversion is technically
+lossy but is fine in practice.
+
+## Structure
+
+```
+Entities
+└── <entity name>                       EntityTypePatch
+    ├── ExperienceAttributes            ExperienceAttributesPatch
+    ├── UnitAttributes                  UnitAttributesPatch
+    ├── ResearchItemAttributes          ResearchItemAttributesPatch
+    ├── UnitHangarAttributes            UnitHangarAttributesPatch
+    ├── DetectableAttributes            DetectableAttributesPatch
+    ├── UnitMovementAttributes          UnitMovementAttributesPatch
+    ├── AbilityAttributes  ── <name> ── AbilityAttributesPatch
+    ├── StorageAttributes  ── <name> ── StorageAttributesPatch
+    └── WeaponAttributes   ── <name> ── WeaponAttributesPatch
+```
+
+## UnitAttributes
+
+| Property | Type | Property | Type |
+| --- | --- | --- | --- |
+| `Class` | `UnitClass` | `SelectionFlags` | `UnitSelectionFlags` |
+| `MaxHealth` | `int` | `Armour` | `int` |
+| `DamageReceivedMultiplier` | `double` | `AccuracyReceivedMultiplier` | `double` |
+| `PopCapCost` | `int` | `ExperienceValue` | `int` |
+| `ProductionTime` | `double` | `Resource1Cost` | `int` |
+| `Resource2Cost` | `int` | `LeadPriority` | `int` |
+| `AggroRange` | `double` | `LeashRange` | `double` |
+| `AlertRange` | `double` | `RepairPickupRange` | `double` |
+| `SensorRadius` | `double` | `ContactRadius` | `double` |
+| `UnitPositionReaggroConditions` | enum | `LeashPositionReaggroConditions` | enum |
+| `Selectable` | `bool` | `Controllable` | `bool` |
+| `Targetable` | `bool` | `NonAutoTargetable` | `bool` |
+| `RetireTargetable` | `bool` | `HackedReturnTargetable` | `bool` |
+| `HackableProperties` | enum | `ExcludeFromUnitStats` | `bool` |
+| `BlocksLOF` | `bool` | `WorldHeightOffset` | `double` |
+| `DoNotPersist` | `bool` | `LevelBound` | `bool` |
+| `StartsInHangar` | `bool` | `PriorityAsTarget` | `double` |
+| `NumProductionQueues` | `int` | `ProductionQueueDepth` | `int` |
+| `ShowProductionQueues` | `bool` | `NoTextNotifications` | `bool` |
+| `NotificationFlags` | enum | `FireRateDisplay` | `int` |
+| `BaseThreat` | `int` | `ThreatTier` | `int` |
+| `ThreatCounters` | `string[]` | `ThreatCounteredBys` | `string[]` |
+
+`AggroRange` is what makes a unit engage on its own. Leaving it alone while raising
+`SensorRadius` gives you vision without the unit chasing things you did not order it to attack.
+
+## UnitMovementAttributes
+
+`DriveType` (`UnitDriveType`), and `Dynamics`:
+
+| Property | Type | Property | Type |
+| --- | --- | --- | --- |
+| `DriveType` | `UnitDriveType` | `MaxSpeed` | `double` |
+| `MinCruiseSpeed` | `double` | `ReverseFactor` | `double` |
+| `AccelerationTime` | `double` | `BrakingTime` | `double` |
+| `MaxSpeedTurnRadius` | `double` | `MaxEaseIntoTurnTime` | `double` |
+| `Length` | `double` | `Width` | `double` |
+| `DriftType` | `double` | `ReverseDriftMultiplier` | `double` |
+| `DriftOvershootFactor` | `double` | `FishTailingTimeIntervals` | `double` |
+| `FishTailControlRecover` | `double` | `MinDriftSlipSpeed` | `double` |
+| `MaxDriftRecoverTime` | `double` | `DeathDriftTime` | `double` |
+| `PermanentlyImmobile` | `bool` | | |
+
+## WeaponAttributes
+
+Keyed by weapon name.
+
+| Property | Type | Property | Type |
+| --- | --- | --- | --- |
+| `BaseDamagePerRound` | `double` | `BaseWreckDamagePerRound` | `double` |
+| `DamageType` | `DamageType` | `DamagePacketsPerShot` | `int` |
+| `RateOfFire` | `int` | `NumberOfBursts` | `int` |
+| `WindUpTimeMS` | `int` | `WindDownTimeMS` | `int` |
+| `BurstPeriodMinTimeMS` | `int` | `BurstPeriodMaxTimeMS` | `int` |
+| `CooldownTimeMS` | `int` | `ReloadTimeMS` | `int` |
+| `FiringRecoil` | `float` | `LineOfSightRequired` | `bool` |
+| `LeadsTarget` | `TargetAimingType` | `TargetStyle` | `WeaponTargetStyle` |
+| `ExcludeFromAutoTargetAcquisition` | `bool` | `ExcludeFromAutoFire` | `bool` |
+| `ExcludeFromHeightAdvantage` | `bool` | `KillSkipsUnitDeathSequence` | `bool` |
+| `AreaOfEffectFalloffType` | `AOEFalloffType` | `AreaOfEffectRadius` | `double` |
+| `ExcludeWeaponOwnerFromAreaOfEffect` | `bool` | `FriendlyFireDamageScalar` | `double` |
+| `WeaponOwnerFriendlyFireDamageScalar` | `double` | `IsTracer` | `bool` |
+| `TracerSpeed` | `double` | `TracerLength` | `double` |
+| `RevealTriggers` | enum | `UnitStatusAttackingTriggers` | enum |
+| `ProjectileEntityTypeToSpawn` | `string` | `ActiveStatusEffectsIndex` | `int` |
+| `StatusEffectsTargetAlignment` | enum | `StatusEffectsExcludeTargetType` | `UnitClass` |
+
+Nested:
+
+- `RangeAttributesShort` / `RangeAttributesMedium` / `RangeAttributesLong` —
+  `Accuracy`, `Distance`, `MinDistance` (all `double`), plus `Remove`
+- `Turret` — `FieldOfView`, `FieldOfFire`, `RotationSpeed` (all `double`)
+- `Modifiers` — **indexed list**, see below
+- `EntityTypesToSpawnOnImpact` — **indexed list** of `EntityTypeToSpawn`, `SpawnRotationOffsetDegrees`
+- `TargetPrioritizationAttributes` — `WeaponEffectivenessWeight`, `TargetThreatWeight`,
+  `DistanceWeight`, `AngleWeight`, `TargetPriorityWeight`, `AutoTargetStickyBias`,
+  `TargetSameCommanderBias`, `TargetWithinFOVBias` (all `double`)
+
+### Modifiers — what a weapon can shoot
+
+Each entry is `TargetClass` (`UnitClass`), `ClassOperator` (`FlagOperator`), `Modifier`
+(`WeaponModifierType`) and `Amount` (`int`). This is where ground-versus-air gating lives, and
+where per-class damage scaling is configured.
+
+`WeaponModifierType`: `CanTarget`, `CanNotTarget`, `DamagePercent`, `DamageValue`,
+`AccuracyShortPercent`, `AccuracyShortValue`, `AccuracyMediumPercent`, `AccuracyMediumValue`,
+`AccuracyLongPercent`, `AccuracyLongValue`
+
+Weapon names encode their role by convention: `_G2G_` ground-to-ground, `_G2A_` ground-to-air,
+`_G2GA_` both. A weapon with `ExcludeFromAutoFire` set is only fired by an ability — grenade and
+smoke launchers work this way, which is why a unit carrying one can still look like it never
+shoots.
+
+## Other components
+
+**AbilityAttributes** (keyed by name) — `AbilityType`, `TargetingType`, `TargetAlignment`,
+`AbilityMapTargetLayers`, `GroundAutoTargetAlignment`, `EdgeOfTargetShapeMinDistance`,
+`CasterMovesToTarget`, `GroupActivationType`, `StartsRemovedInGameMode`, `CooldownTimeSecs`,
+`WarmupTimeSecs`, `SharedCooldownChannel`, `SkipCastOnArrivalConditions`, `IsToggleable`,
+`CastOnDeath`, `Resource1Cost`, `Resource2Cost`
+
+**ResearchItemAttributes** — `TypeOfResearch` (`ResearchType`), `IconSpriteName`,
+`LocalizedResearchTitleStringID`, `LocalizedShortDescriptionStringID`,
+`LocalizedLongDescriptionStringID`, `ResearchTime`, `Dependencies` (`string[]`), `ResearchVOCode`,
+`Resource1Cost`, `Resource2Cost`
+
+**DetectableAttributes** — `DisplayLastKnownLocation`, `LastKnownDuration`,
+`TimeVisibleAfterFiring`, `AlwaysVisible`, `MinimumStateAfterDetection` (`DetectionState`),
+`FOWFadeDuration`, `SetHasBeenSeenBeforeOnSpawn`
+
+**ExperienceAttributes** — `Levels`, an **indexed list** of `BuffTooltipLocID`,
+`RequiredExperience`, and `Buff` (itself an indexed list of `Name`, `Attribute`, `Mode`, `Value`)
+
+**StorageAttributes** (keyed by name) — `LinkToPlayerBank`, `IsResourceController`, and
+`InventoryLoadout` keyed by inventory ID with `Capacity`, `HasUnlimitedCapacity`, `StartingAmount`.
+A new inventory ID creates a new inventory.
+
+**UnitHangarAttributes** — `AlignmentTime`, `ApproachTime`, and `HangarBays` keyed by bay name
+with 24 docking and undocking properties.
+
+## Enum values
+
+| Enum | Values |
+| --- | --- |
+| `UnitClass` (flags) | `None`, `Air`, `Ground`, `Hover`, `Carrier`, `ScriptControlled`, `Small`, `Medium`, `Large`, `XLarge`, `Strikecraft`, `Armored`, `Ranged`, `Harvester`, `Support`, `All` |
+| `WeaponModifierType` | `CanTarget`, `CanNotTarget`, `DamagePercent`, `DamageValue`, `AccuracyShortPercent`, `AccuracyShortValue`, `AccuracyMediumPercent`, `AccuracyMediumValue`, `AccuracyLongPercent`, `AccuracyLongValue` |
+| `FlagOperator` | `Or`, `And` |
+| `TargetAimingType` | `DirectAtTarget`, `LeadTarget` |
+| `WeaponTargetStyle` | `RandomSpray`, `TurretImpactRun`, `Flak` |
+| `AOEFalloffType` | `None`, `Linear`, `Quadratic` |
+| `DamageType` | `Damage`, `Heal` |
+| `UnitDriveType` | `Wheeled`, `Tracked`, `Hover`, `Air` |
+| `DetectionState` | `Hidden`, `Contacted`, `Sensed` |
+| `HackableProperties` | `NonHackable`, `Hackable`, `InstantHackable` |
+| `ResearchType` | `Engineering`, `Upgrade` |
+
+`SubsystemLint` validates enum values and lists the legal ones when you get it wrong, which is
+usually faster than looking them up. For any enum not listed here, its definition is in
+`Data/Managed/BBI.Game.Data.dll`.

--- a/docs/patch-reference.md
+++ b/docs/patch-reference.md
@@ -277,6 +277,57 @@ key on the local player; that is why there is no "me" and no name-based lookup h
 Giving one commander better units is, of course, an unfair game. This is aimed at single-player
 and at skirmishes against the AI.
 
+### AddAbilities — giving units an ability they do not ship with
+
+Buffs can only tune an ability a unit already has. `AddAbilities` copies a whole ability onto one
+commander's units, which is how you give a unit self-repair:
+
+```json
+"Commanders": {
+  "1": {
+    "AddAbilities": {
+      "C_": {
+        "UseAsPrefix": true,
+        "Abilities": {
+          "0": { "From": "Ability_C_Battlecruiser_Regen" }
+        }
+      }
+    }
+  }
+}
+```
+
+`From` is the entity type name of the ability to copy — abilities are entity types in their own
+right, and `Subsystem.entities.log` lists each one with what it actually does:
+
+```
+Ability_C_Battlecruiser_Regen
+    AbilityAttributesData: Ability_C_Battlecruiser_Regen
+        type: ApplyStatusEffect   targeting: Passive   cooldown: 0s   warmup: 0s
+        applies status effect: Regen_Salvager_StatusEffect   lifetime: Permanent
+        health over time: 24 per 1000ms, Heal, id "Passive_Regeneration"
+```
+
+Matching works exactly as it does for `EntityTypeBuffs` — `UseAsPrefix`, `UnitClass` and
+`ClassOperator` all behave the same way.
+
+**`targeting: Passive` is the flag that matters.** `UnitManager.ActivatePassiveAbilities` fires
+passive abilities as a unit spawns, with no button and no player input. An ability that is not
+passive still gets added, but nothing will trigger it; `Subsystem.log` says so rather than
+leaving you to wonder.
+
+`SkipIfSelfHealing` defaults to true: a unit that already regenerates is left alone, decided by
+walking its abilities for a healing health-over-time effect rather than by any hard-coded list.
+Set it to `false` to stack regeneration on top of what a unit already has.
+
+Two things to expect:
+
+- **A unit gets its abilities when it spawns.** Vehicles already on the field keep the ability
+  list they were built with, so a granted ability shows up on newly built units and on everything
+  from the next mission onward — never on the fleet standing in front of you.
+- Unlike buffs, this is **not** saved with the game. It is re-applied on every mission load,
+  which is why it has to be idempotent, and it is: an ability already present is not added twice.
+
 ### Proving it is really per-commander
 
 Buffing your own faction is not a test. In the campaign you are Coalition (`C_`) and the enemy is

--- a/docs/patch-reference.md
+++ b/docs/patch-reference.md
@@ -31,6 +31,13 @@ This is what `SubsystemLint` is for. Run it before you launch.
 Names behave differently: an entity or component name that does not exist skips only that entry
 and is reported in `Subsystem.log`.
 
+### Comments are allowed, trailing commas are not
+
+The LitJson bundled in `BBI.Core.dll` skips `//` line comments and `/* */` block comments, so
+you can annotate `patch.json` freely — `patch.example.json` does. It does **not** accept a
+trailing comma; one throws `Invalid token '125' in input string`, which discards the whole file
+exactly like an unknown key does. `SubsystemLint` applies both rules.
+
 ### Lists are keyed by index, not by name
 
 Five properties are lists, and their keys must be consecutive integers as strings:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,7 @@ Check `Data/output_log.txt`:
 | What you see | Meaning |
 | --- | --- |
 | no `Platform assembly: ...Subsystem.dll` line | `Subsystem.dll` is not in `Data/Managed/` |
-| that line, but no `[SUBSYSTEM]` line | the hook is not in `BBI.Unity.Game.dll` — run the patcher |
+| that line, but no `[SUBSYSTEM]` line | the hooks are not in `BBI.Unity.Game.dll` — run the patcher |
 | `[SUBSYSTEM] Error applying patch file: ...` | `patch.json` failed to parse — see below |
 | `[SUBSYSTEM] Applied attributes patch.` | it worked; read `Data/Subsystem.log` |
 
@@ -101,10 +101,34 @@ Before assuming the mod broke it, check what the unit can actually shoot. In
 To confirm a weapon is not the problem, patch the unit with **no** `WeaponAttributes` block at
 all and see whether the behaviour changes. If it does not, the weapon data was never involved.
 
+## A commander buff did nothing
+
+`Subsystem.log` gets a `Commander buffs` section at the end of every match start. Read it first —
+it names the commanders that exist and reports every entity type it touched.
+
+| What the log says | Meaning |
+| --- | --- |
+| no `Commander buffs` section at all | there is no `Commanders` key in `patch.json`, or the second hook is missing — run `SubsystemPatcher --verify` |
+| `ERROR: ... EntityTypeBuffExtensions not found` | a game update moved the engine API this depends on; commander buffs are unavailable until it is re-identified |
+| `NOTICE: matched no entity type with UnitAttributes` | the entity name (or prefix, or `UnitClass` filter) matched nothing that can be buffed |
+| `already applied` | the buff was restored from a save; this is the deduplication working, not a failure |
+| `applied N of M buff(s)` | it worked |
+
+If the log says it applied and the stat still looks unchanged, the usual suspects from the
+section above apply — most often that the unit already existed.
+
+**A weapon buff that reports as applied but changes nothing** is almost always the wrong `Name`.
+Weapon buffs key on the loadout's weapon ID, not on the weapon component name that the `Entities`
+section uses. `Subsystem.entities.log` prints the right one as
+`weapon ID (for commander buffs)`. Omitting `Name` buffs every weapon on the unit and sidesteps it.
+
+**Buffing the wrong commander** produces no error, because any commander ID is a legal key. Check
+the `local commander:` line in the log and key on that number.
+
 ## A list entry did not apply
 
-`Modifiers`, `EntityTypesToSpawnOnImpact`, `Levels` and `Buff` are keyed by **list index**, not by
-name. A key that is not an integer, or that is greater than the current number of entries, stops
+`Modifiers`, `EntityTypesToSpawnOnImpact`, `Levels`, `Buff` and `Buffs` are keyed by **list
+index**, not by name. A key that is not an integer, or that is greater than the current number of entries, stops
 processing of that list. See
 [the rule](patch-reference.md#lists-are-keyed-by-index-not-by-name).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,139 @@
+# Troubleshooting
+
+Symptoms first, in roughly the order people hit them.
+
+## The game breaks between the menu and a match
+
+You have the 0.4.0 `BBI.Unity.Game.dll` installed. That file is the whole 2018 game assembly, and
+dropping it on a current install rolls back years of game code. See
+[compatibility.md](compatibility.md).
+
+```sh
+dotnet run --project SubsystemPatcher -c Release -- --verify
+```
+
+If it reports `matches this install : NO — N dangling references`, restore the real file:
+
+- `dotnet run --project SubsystemPatcher -c Release -- --restore`, or
+- Steam → right-click the game → Properties → Installed Files → Verify integrity
+
+Then install properly, per the [README](../README.md#installation).
+
+## Nothing happens at all, and there is no Subsystem.log
+
+Check `Data/output_log.txt`:
+
+| What you see | Meaning |
+| --- | --- |
+| no `Platform assembly: ...Subsystem.dll` line | `Subsystem.dll` is not in `Data/Managed/` |
+| that line, but no `[SUBSYSTEM]` line | the hook is not in `BBI.Unity.Game.dll` — run the patcher |
+| `[SUBSYSTEM] Error applying patch file: ...` | `patch.json` failed to parse — see below |
+| `[SUBSYSTEM] Applied attributes patch.` | it worked; read `Data/Subsystem.log` |
+
+Remember that **a game update replaces `BBI.Unity.Game.dll` and removes the hook.** The symptom
+is the mod silently doing nothing. Re-run the patcher.
+
+## "Error applying patch file" — one typo killed everything
+
+An unknown property makes LitJson throw, which discards the **entire** patch, not just the bad
+entry. See [the rule](patch-reference.md#an-unknown-key-discards-the-entire-patch).
+
+```sh
+dotnet run --project SubsystemLint -c Release
+```
+
+It will point at the offending key and usually suggest the correct spelling.
+
+## Subsystem.log says the entity or component was not found
+
+```
+NOTICE: EntityType not found
+ERROR: WeaponAttributes not found
+```
+
+The name does not exist in your install. Common causes:
+
+- **Campaign versus multiplayer.** Most units exist twice — `C_HAC` and `C_HAC_MP` — and their
+  components carry matching suffixes, but not always the same one: the campaign G2A weapon is
+  `..._Weapon_G2A_Campaign`, not unsuffixed.
+- **Names changed since 2018.** `Tier_3_C_Artillery` from the old README no longer exists.
+- **The component name is not the entity name.** `C_HAC_Upgrade01_MP` carries a weapon called
+  `C_HAC_Upgrade01_Weapon_G2A_MP`.
+
+`Data/Subsystem.entities.log` lists every valid name; `SubsystemLint` checks your file against it.
+
+## Subsystem.log shows the change, but the game does not
+
+Almost always one of these three.
+
+**The unit already existed.** Health, armour, speed, pop cost and sensor radius are copied into a
+unit's simulation state when it spawns. Existing units — including everything in a saved game —
+keep the old values. Build a new one, or start a new match.
+
+**You are looking at a buffed unit.** The stat card shows live state including veterancy and
+upgrades, so a unit with a base `MaxSpeed` of 50 can read `SPEED 65`. A freshly built unit shows
+the base value.
+
+**You patched the variant you are not playing.** Patching the `_MP` entity does nothing in
+campaign, and vice versa. Patching both in one file is harmless and avoids the question entirely.
+
+## A unit will not shoot
+
+Before assuming the mod broke it, check what the unit can actually shoot. In
+`Data/Subsystem.entities.log`:
+
+```
+    WeaponAttributesData: C_HAC_Upgrade01_Weapon_G2A_MP
+        auto-acquire: yes   auto-fire: yes   damage: 250   cooldown: 700ms
+        ranges: Short=1400 Medium=1400 Long=1400
+        vs Air (Or): CanTarget 1
+```
+
+- **`_G2A_` means anti-air only.** It will never engage ground targets. `_G2G_` is ground,
+  `_G2GA_` is both. This is vanilla behaviour, not a modding failure.
+- **`auto-fire: no` means you have to fire it.** Grenade and smoke launchers are abilities. The
+  unit will sit there looking idle until you trigger them.
+- **`ranges` is the actual reach.** Raising `SensorRadius` and `AggroRange` well beyond the
+  weapon's range makes a unit acquire targets it cannot shoot, which looks like it is refusing to
+  fire. Either raise the range bands to match or leave the aggro range alone.
+- **`vs <class>` lines gate targeting.** `CanNotTarget` against a class means exactly that.
+
+To confirm a weapon is not the problem, patch the unit with **no** `WeaponAttributes` block at
+all and see whether the behaviour changes. If it does not, the weapon data was never involved.
+
+## A list entry did not apply
+
+`Modifiers`, `EntityTypesToSpawnOnImpact`, `Levels` and `Buff` are keyed by **list index**, not by
+name. A key that is not an integer, or that is greater than the current number of entries, stops
+processing of that list. See
+[the rule](patch-reference.md#lists-are-keyed-by-index-not-by-name).
+
+## Multiplayer desync
+
+Every player needs the same Subsystem version and byte-identical `patch.json`. There is no
+partial compatibility.
+
+## Unrelated errors you can ignore
+
+These appear in `output_log.txt` on a healthy install and have nothing to do with Subsystem:
+
+```
+NullReferenceException
+  at PlayEveryWare.EpicOnlineServices.EOSManager.GetEOSP2PInterface ()
+  at GG.EpicGames.EpicP2PIntegration.IsP2PPacketAvailable (...)
+```
+
+Epic Online Services when you are offline or not signed in. Likewise `Error: Online: [SPARK]
+Service encountered an error!`, `NameResolutionFailure`, missing shader fallbacks, and the game's
+own `Tried to add invalid ability type name ...` messages.
+
+## Starting over
+
+```sh
+dotnet run --project SubsystemPatcher -c Release -- --restore
+```
+
+Restores the original `BBI.Unity.Game.dll` byte-for-byte from the backup the patcher made. Delete
+`Subsystem.dll`, `patch.json`, `Subsystem.log`, `Subsystem.entities.log` and
+`BBI.Unity.Game.dll.subsystem-backup` for a fully clean install. Verifying the game files in
+Steam also works if the backup is gone.

--- a/patch.example.json
+++ b/patch.example.json
@@ -1,14 +1,87 @@
+// Subsystem example patch. Copy to "Deserts of Kharak/Data/patch.json".
+//
+// Comments are fine -- the game's JSON parser skips // and /* */. A trailing comma is not:
+// it throws, and one throw anywhere discards the WHOLE file. So does one misspelled key.
+// Run SubsystemLint before you launch and it will tell you which.
+//
+// Names are case-sensitive and come from Data/Subsystem.entities.log, which the mod rewrites
+// on every game start from what your install actually loaded. Campaign and multiplayer are
+// separate entity types: C_HAC in the campaign, C_HAC_MP in skirmish and multiplayer.
 {
+  // ---------------------------------------------------------------------------------------
+  // Entities -- patches the shared unit templates. Applies to EVERY player fielding the unit.
+  // Reaches every property Subsystem knows about. See docs/patch-reference.md.
+  // ---------------------------------------------------------------------------------------
   "Entities": {
+
     "G_Baserunner_MP": {
       "UnitAttributes": {
         "MaxHealth": 9999
       }
     },
+
     "C_Escort_MP": {
+      // Weapons here are keyed by the weapon COMPONENT name, as printed in the entity dump.
+      // Commander buffs below key on something else -- see the note there.
       "WeaponAttributes": {
         "C_Escort_Weapon_G2G_MP": {
           "BaseDamagePerRound": 40
+        }
+      }
+    }
+  },
+
+  // ---------------------------------------------------------------------------------------
+  // Commanders -- changes that apply to ONE player's units and leave everyone else's alone.
+  // Uses the game's own attribute-buff system, the one research upgrades run on, so these
+  // survive loading a save. In exchange only the attributes the engine can buff are
+  // reachable; docs/patch-reference.md lists all of them.
+  //
+  // Keyed by commander ID, a number. Subsystem.log prints the roster at every match start:
+  //
+  //     local commander: 1
+  //     first enemy CPU commander: 3
+  //       commander 1: COALITION (team 1)
+  //       commander 3: SIIDIM (team 3)
+  //
+  // Key on that number, never on "whoever is playing" -- in multiplayer that would resolve
+  // differently on each machine and desync the game.
+  // ---------------------------------------------------------------------------------------
+  "Commanders": {
+
+    "1": {
+      "EntityTypeBuffs": {
+
+        "C_Escort_MP": {
+          // Buffs is an indexed list: keys "0", "1", "2", ... with no gaps.
+          // Mode is Add, AddPercent, Set or SetAndHold. Value is always a whole number, so
+          // express a fraction as a percentage: AddPercent -60 leaves you at x0.4.
+          "Buffs": {
+            "0": { "Attribute": "Unit_MaxHealth", "Mode": "Set", "Value": 5000 },
+            "1": { "Attribute": "Unit_DamageReceivedMultiplier", "Mode": "AddPercent", "Value": -60 },
+            "2": { "Attribute": "UnitDynamics_MaxSpeed", "Mode": "AddPercent", "Value": 25 },
+
+            // For weapon and range buffs, "Name" is the weapon's LOADOUT ID, which is not the
+            // component name the Entities section uses -- C_Escort_Weapon_G2G_MP has the ID
+            // "DEFAULT". The entity dump prints it as "weapon ID (for commander buffs)".
+            // Leave Name out to hit every weapon on the unit.
+            "3": { "Attribute": "UnitWeapon_BaseDamagePerRound", "Name": "DEFAULT", "Mode": "Set", "Value": 200 },
+
+            // A range band can only be buffed if the weapon already has it. Buffs cannot
+            // create one; the Entities section can.
+            "4": { "Attribute": "WeaponRange_DistanceLong", "Name": "DEFAULT", "Mode": "AddPercent", "Value": 50 }
+          }
+        },
+
+        // UseAsPrefix matches every entity type whose name starts with the key, so this is
+        // "every Coalition multiplayer unit". UnitClass narrows it further; omit for no filter.
+        "C_": {
+          "UseAsPrefix": true,
+          "UnitClass": "Air",
+          "ClassOperator": "Or",
+          "Buffs": {
+            "0": { "Attribute": "Unit_Armour", "Mode": "Add", "Value": 2 }
+          }
         }
       }
     }

--- a/patch.example.json
+++ b/patch.example.json
@@ -1,0 +1,16 @@
+{
+  "Entities": {
+    "G_Baserunner_MP": {
+      "UnitAttributes": {
+        "MaxHealth": 9999
+      }
+    },
+    "C_Escort_MP": {
+      "WeaponAttributes": {
+        "C_Escort_Weapon_G2G_MP": {
+          "BaseDamagePerRound": 40
+        }
+      }
+    }
+  }
+}

--- a/patch.example.json
+++ b/patch.example.json
@@ -83,6 +83,27 @@
             "0": { "Attribute": "Unit_Armour", "Mode": "Add", "Value": 2 }
           }
         }
+      },
+
+      // Buffs can only tune an ability a unit already has. AddAbilities copies a whole one on,
+      // which is how you give a unit self-repair it does not ship with. "From" is the entity
+      // type name of the ability; the entity dump lists them all with what each one does.
+      //
+      // Only an ability with "targeting: Passive" fires by itself as the unit spawns. Anything
+      // else is added but never triggered, and Subsystem.log says so.
+      //
+      // Units already on the field keep the abilities they were built with, so this shows up on
+      // newly built units. Unlike buffs it is not saved with the game -- it is re-applied on
+      // every mission load, and an ability already present is never added twice.
+      "AddAbilities": {
+        "C_": {
+          "UseAsPrefix": true,
+          "Abilities": {
+            // 24 health/sec, permanent. SkipIfSelfHealing defaults to true, so units that
+            // already regenerate are left alone.
+            "0": { "From": "Ability_C_Battlecruiser_Regen", "SkipIfSelfHealing": true }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
# Restore compatibility with current versions of the game

Fixes #11.

## The problem

The 0.4.0 release ships a complete, pre-patched `BBI.Unity.Game.dll` — the whole game assembly as
it existed in November 2018 — and the install instructions say to overwrite the game's own copy.
On any later build that replaces years of game code, which is why the main menu misbehaves and
the transition into a match fails.

The actual modification inside that 1.85 MB file is three IL instructions at the end of
`ShipbreakersMain.ResetEntityManager`:

```
newobj  instance void Subsystem.AttributeLoader::.ctor()
ldsfld  class BBI.Core.Data.EntityTypeCollection BBI.Unity.Game.ShipbreakersMain::sEntityTypes
call    instance void Subsystem.AttributeLoader::LoadAttributes(class BBI.Core.Data.EntityTypeCollection)
```

Everything else is just the 2018 game. Checked against a current install, that assembly references
**19 types and 51 members that no longer exist**, concentrated in `BBI.Steam`, `BBI.Spark` and
`BBI.Unity.Game.Data` — the lobby, leaderboard, stats and DLC layers, rewritten when the game
moved to Epic Online Services. Those throw as soon as the affected code is JIT-compiled, which is
exactly where the reported symptoms appear.

**`Subsystem.dll` itself was never broken.** Against a current install it resolves every type and
member reference it uses, all 21 wrapper classes still satisfy the game interfaces they implement,
and every wrapper copy-constructor still copies 100% of its interface's properties. The 2018
sources compile against current game assemblies with no errors and no warnings. Only the delivery
mechanism was broken.

## The fix

`SubsystemPatcher` applies those three instructions to whatever `BBI.Unity.Game.dll` the user
actually has, rather than replacing the file. It keeps working across game updates — you re-run it
after each one.

It backs the original up before writing, restores it byte-for-byte, is idempotent, and refuses to
run against an assembly whose references do not resolve against the rest of the install, which is
what an old pre-patched copy looks like.

The rewrite was verified rather than assumed:

- Comparing an opcode-and-operand fingerprint of all **15,907 members** before and after, only
  `ResetEntityManager` differs: +3 instructions, its 2 exception handlers and 9 locals intact.
- All **26,312 lines** of custom attributes and metadata flags are byte-identical — 109
  `[Serializable]` types, 10 `[NonSerialized]` fields, class layout, security declarations.
- No embedded resources, exported types, module references or P/Invoke exist to lose; `ILOnly`
  and the 32-bit architecture flag are preserved.
- `--restore` reproduces the original file's checksum exactly.

## What else is in here

**`build/Subsystem.Sdk.csproj`** — the existing project is legacy-format with no `HintPath`s, so it
only ever built where Visual Studio happened to resolve the game assemblies. This compiles the
same sources with nothing but the .NET SDK, on any OS, referencing the assemblies from the game
install. The original project file is left in place.

**`EntityTypeDumper`** — writes `Data/Subsystem.entities.log` on every game start: every entity
type the game loaded, its components, and for weapons the ranges, auto-fire flags and
per-target-class modifiers. The only published name list is the 2018 gist, and names have changed
since. It is written before the patch is read, so it is still produced when `patch.json` is
missing or malformed.

**`SubsystemLint`** — validates a `patch.json` against the shapes Subsystem deserializes and the
names the install actually loaded. This matters more than it sounds: LitJson's `ignore_extra_keys`
is never assigned and defaults to `false`, so **one unknown key makes the whole document throw**
and nothing is patched at all. A single typo silently disables the entire file, with one line in
the player log as the only clue.

**CI and release workflows** — CI builds both tools. The mod assembly cannot be built on CI at all,
since it references assemblies that ship with the game and cannot be redistributed, so CI instead
checks that its build guard still fires. The release workflow runs on `v*` tags and publishes the
tools as portable framework-dependent builds (~600 KB, runs on every OS) packaged with the docs,
the mod sources and the build project, so users can extract it and build `Subsystem.dll` against
their own installation.

**Documentation** — `docs/compatibility.md` records what broke and why so it does not have to be
rediscovered; `docs/patch-reference.md` covers every patchable property and the non-obvious rules;
`docs/finding-names-and-values.md` covers discovering names for a given install;
`docs/troubleshooting.md` is symptom-first; `docs/building.md` covers the build and release
process. The install instructions, dead source links, and an example referencing an entity the
game no longer has are all fixed.

## Compatibility

No behavioural change to existing patch files. The hook site, the instructions injected and the
timing are identical to 0.4.0, so an existing `patch.json` behaves exactly as before.

## Testing

Verified against Steam build 12339551 on Linux under Proton: patch, verify, re-patch, restore
round-trip, rejection of a mismatched assembly, and in-game confirmation that attribute changes
apply and are reported in `Subsystem.log`.

## About this contribution

I built this because I wanted to play the game with my own tweaks and the old install method no
longer worked. I am not volunteering to maintain Subsystem, and nothing here should be read as a
commitment to support it — I work on the parts I happen to be curious about, when I feel like it.

Take it, change it, or ignore it. I am happy to answer questions on this PR and to fix anything
you want changed before merging, but please do not route issues or future game breakage to me by
default.

That is also why `docs/` is as thorough as it is. Everything I worked out — the hook, the failure
mode, the verification, the traps in the patch format — is written down specifically so the next
person does not have to ask me, or rediscover it from scratch the way I did.
